### PR TITLE
fix(gerber-plotter): Board outline regression

### DIFF
--- a/packages/gerber-plotter/lib/path-graph.js
+++ b/packages/gerber-plotter/lib/path-graph.js
@@ -125,7 +125,7 @@ PathGraph.prototype._fillGapsAndOptimize = function () {
     })
 
     if (existing != null) {
-      return
+      continue
     }
 
     var newEdgeIndex = this._edges.length

--- a/packages/gerber-plotter/lib/path-graph.js
+++ b/packages/gerber-plotter/lib/path-graph.js
@@ -124,20 +124,18 @@ PathGraph.prototype._fillGapsAndOptimize = function () {
       return lineSegmentsEqual(edge.segment, newSeg)
     })
 
-    if (existing != null) {
-      continue
+    if (!existing) {
+      var newEdgeIndex = this._edges.length
+      var edge = {segment: newSeg, start: start, end: end}
+
+      points[startIndex].edges.push(newEdgeIndex)
+      points[startIndex].position = edge.start.position
+      points[endIndex].edges.push(newEdgeIndex)
+      points[endIndex].position = edge.end.position
+
+      this._edges.push(edge)
+      this.length++
     }
-
-    var newEdgeIndex = this._edges.length
-    var edge = {segment: newSeg, start: start, end: end}
-
-    points[startIndex].edges.push(newEdgeIndex)
-    points[startIndex].position = edge.start.position
-    points[endIndex].edges.push(newEdgeIndex)
-    points[endIndex].position = edge.end.position
-
-    this._edges.push(edge)
-    this.length++
   }
 
   // consolidate all the connecting edges to prepare for a depth first

--- a/packages/gerber-plotter/test/path-graph_test.js
+++ b/packages/gerber-plotter/test/path-graph_test.js
@@ -139,6 +139,19 @@ describe('path graphs', function () {
     expect(p.length).to.equal(1)
   })
 
+  it('should not allow duplicate line segments but it should continue', function () {
+    p.add({type: 'line', start: [1, 0], end: [1, 2]})
+    p.add({type: 'line', start: [0, 0], end: [1, 0]})
+    p.add({type: 'line', start: [1, 0], end: [0, 0]})
+    p.add({type: 'line', start: [0, 0], end: [1, 0]})
+    p.add({type: 'line', start: [1, 0], end: [1, 2]})
+    p.add({type: 'line', start: [1, 2], end: [1, 3]})
+    p.add({type: 'line', start: [1, 3], end: [2, 3]})
+    p.add({type: 'line', start: [1, 3], end: [2, 3]})
+    p.traverse()
+    expect(p.length).to.equal(4)
+  })
+
   it('should not optimize the path if passed a false during construction', function () {
     p = new PathGraph(false)
 


### PR DESCRIPTION
I am looking at the regression observed in the outlines drawn from the bus-pirate ~~and maulwurf~~ example boards. This is most likely something to do with trying to use the closest point for outline gap filling which was added to the gerber-plotter recently and seemed to be working well for the usbvil board. 