### PR TITLE
fix(pcb-stackup): Catch RangeErrors when SVG is too big to stack

### DIFF
--- a/packages/pcb-stackup/index.js
+++ b/packages/pcb-stackup/index.js
@@ -80,7 +80,13 @@ var pcbStackup = function (layers, options, done) {
 
   var finishLayer = function () {
     if (--layerCount < 1) {
-      var stackup = createStackup(stackupLayers, options)
+      try {
+        var stackup = createStackup(stackupLayers, options)
+      } catch (e) {
+        if (e instanceof RangeError) {
+          return done(new Error('Too big to stackup.'))
+        }
+      }
 
       stackup.layers = stackupLayers
 


### PR DESCRIPTION
Found this by coincidence. Change is by @zacharyfox: https://github.com/MacroFab/pcb-stackup/commit/189c97887e2b6b5ad28c37af78ad21407758ed94