### PR TITLE
feat(whats-that-gerber): Add support for diptrace filenames

### DIFF
--- a/packages/fixtures/gerber-filenames.json
+++ b/packages/fixtures/gerber-filenames.json
@@ -148,5 +148,20 @@
       {"name": "copper_top.gbr",          "type": "tcu"},
       {"name": "silkscreen_bottom.gbr",   "type": "bss"}
     ]
+  },
+  {
+    "cad": "diptrace",
+    "files": [
+      {"name": "BoardOutline.gbr", "type": "out"},
+      {"name": "Through.drl",      "type": "drl"},
+      {"name": "TopMask.gbr",      "type": "tsm"},
+      {"name": "TopSilk.gbr",      "type": "tss"},
+      {"name": "BottomMask.gbr",   "type": "bsm"},
+      {"name": "Bottom.gbr",       "type": "bcu"},
+      {"name": "BottomPaste.gbr",  "type": "bsp"},
+      {"name": "TopPaste.gbr",     "type": "tsp"},
+      {"name": "Top.gbr",          "type": "tcu"},
+      {"name": "BottomSilk.gbr",   "type": "bss"}
+    ]
   }
 ]

--- a/packages/whats-that-gerber/README.md
+++ b/packages/whats-that-gerber/README.md
@@ -88,6 +88,7 @@ We should be able to identify files output by the following programs:
 * Altium
 * Orcad
 * gEDA PCB
+* DipTrace
 
 ## contributing
 

--- a/packages/whats-that-gerber/index.js
+++ b/packages/whats-that-gerber/index.js
@@ -21,7 +21,7 @@ var layerTypes = [
     name: {
       en: 'top copper'
     },
-    match: /((F.Cu)|(copper_top)|(\.top\.gbr$))|(\.((cmp$)|(top$)|(gtl$)))|(\.toplayer\.ger$)|(top copper\.txt$)/i
+    match: /((F.Cu)|(copper_top)|((\.|^)top\.gbr$))|(\.((cmp$)|(top$)|(gtl$)))|(\.toplayer\.ger$)|(top copper\.txt$)/i
   },
   {
     id: 'tsm',
@@ -49,7 +49,7 @@ var layerTypes = [
     name: {
       en: 'bottom copper'
     },
-    match: /(B.Cu|(copper_bottom)|\.bottom\.gbr$)|(\.((sol$)|(bot$)|(gbl$)))|(\.bottomlayer\.ger$)|(bottom copper\.txt$)/i
+    match: /(B.Cu|(copper_bottom)|(\.|^)bottom\.gbr$)|(\.((sol$)|(bot$)|(gbl$)))|(\.bottomlayer\.ger$)|(bottom copper\.txt$)/i
   },
   {
     id: 'bsm',
@@ -70,7 +70,7 @@ var layerTypes = [
     name: {
       en: 'bottom solderpaste'
     },
-    match: /(B.Paste)|(solderpaste_bottom)|(\.((crs$)|(bsp$)|(gbp$)|(spb$)))|(\.bcream\.ger$)/i
+    match: /(B.Paste)|(solderpaste_bottom)|(BottomPaste)|(\.((crs$)|(bsp$)|(gbp$)|(spb$)))|(\.bcream\.ger$)/i
   },
   {
     id: 'icu',
@@ -84,7 +84,7 @@ var layerTypes = [
     name: {
       en: 'board outline'
     },
-    match: /(Edge.Cuts)|(profile)|(\.((dim$)|(mil$)|(gm(l|\d{1,2})$)|(gko$)|(fab$)))|(\.boardoutline\.ger$)|(\.outline\.gbr$)|(mechanical \d+\.txt$)/i
+    match: /(Edge.Cuts)|(profile)|(\.((dim$)|(mil$)|(gm(l|\d{1,2})$)|(gko$)|(fab$)))|(\.boardoutline\.ger$)|((board|\.)outline\.gbr$)|(mechanical \d+\.txt$)/i
   },
   {
     id: 'drl',


### PR DESCRIPTION
I know you are re-writing whats-that-gerber in #77 but I thought I would quickly fix this as it's kind of ruining [this board on Kitspace](https://kitspace.org/boards/github.com/robotsrulz/sp_adapter/). At one point we had good enough DipTrace support accidentally that I didn't even notice it was DipTrace but it's slowly been eroded away over time.