### PR TITLE
 style: Simplify lint setup to lean more heavily on prettier 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// HACK: overriding parserOptions doesn't seem to do anything because
+// eslint-config-standard specifies it; delete it as a workaround
+const standard = require('eslint-config-standard')
+delete standard.parserOptions
+
+module.exports = {
+  parserOptions: {ecmaVersion: 5},
+  env: {es6: false},
+  extends: [
+    'standard',
+    'prettier',
+    'prettier/standard',
+    'plugin:prettier/recommended',
+  ],
+  overrides: [
+    {
+      files: [
+        'packages/cli/**/*.js',
+        'packages/fixtures/**/*.js',
+        '**/integration/**/*.js',
+        '**/example/**/*.js',
+        '**/scripts/**/*.js',
+      ],
+      parserOptions: {ecmaVersion: 6},
+      env: {es6: true},
+    },
+    {
+      files: ['**/*test.js'],
+      env: {mocha: true},
+    },
+  ],
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = {
+  semi: false,
+  singleQuote: true,
+  trailingComma: 'es5',
+  bracketSpacing: false,
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,4 +1,4 @@
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
     frameworks: ['browserify', 'mocha'],
 
@@ -7,12 +7,12 @@ module.exports = function (config) {
     exclude: ['**/integration/**'],
 
     preprocessors: {
-      './packages/**/*test.js': ['browserify']
+      './packages/**/*test.js': ['browserify'],
     },
 
     browserify: {
       debug: true,
-      plugin: ['proxyquire-universal']
+      plugin: ['proxyquire-universal'],
     },
 
     reporters: ['progress'],
@@ -29,6 +29,6 @@ module.exports = function (config) {
 
     singleRun: process.env.CI,
 
-    concurrency: Infinity
+    concurrency: Infinity,
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,8 +1046,7 @@
           "dependencies": {
             "pify": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+              "bundled": true
             }
           }
         }
@@ -1170,12 +1169,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.3.0"
       }
-    },
-    "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
     },
     "amqplib": {
       "version": "0.5.2",
@@ -1537,75 +1530,6 @@
         }
       }
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -1830,12 +1754,6 @@
           "dev": true
         }
       }
-    },
-    "boolify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/boolify/-/boolify-1.0.1.tgz",
-      "integrity": "sha1-tcCeF8rNET0Rt7s+04TMASmU2Gs=",
-      "dev": true
     },
     "boom": {
       "version": "2.10.1",
@@ -2331,12 +2249,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -3265,38 +3177,44 @@
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
+        "globby": "^6.1.0",
         "is-path-cwd": "^1.0.0",
         "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
         "rimraf": "^2.2.8"
       },
       "dependencies": {
         "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
             "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
             "glob": "^7.0.3",
             "object-assign": "^4.0.1",
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
           }
         },
         "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
       }
@@ -3429,12 +3347,6 @@
           "dev": true
         }
       }
-    },
-    "dlv": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.2.tgz",
-      "integrity": "sha512-xxD4VSH67GbRvSGUrckvha94RD7hjgOH7rqGxiytLpkaeMvixOHFZTGFK6EkIm3T761OVHT8ABHmGkq9gXgu6Q==",
-      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
@@ -3870,10 +3782,27 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.1.0.tgz",
+      "integrity": "sha512-QYGfmzuc4q4J6XIhlp8vRKdI/fI0tQfQPy1dME3UOLprE+v4ssH/3W9LM2Q7h5qBcy5m0ehCrBDU2YF8q6OY8w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-config-standard": {
-      "version": "11.0.0",
-      "resolved": "http://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz",
-      "integrity": "sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -3930,6 +3859,16 @@
         }
       }
     },
+    "eslint-plugin-es": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.2.tgz",
+      "integrity": "sha512-xrdbConViY20DhGrt9FwjhDo4fr/9Yus2pYf0xJsdJaCcUzMq7+pAoNH7kSXF6V08bRHMpgDWclYbcr/Sn3hNg==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.1"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
@@ -3976,27 +3915,46 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "6.0.1",
-      "resolved": "http://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.0.tgz",
+      "integrity": "sha512-Y+ln8iQ52scz9+rSPnSWRaAxeWaoJZ4wIveDR0vLHkuSZGe44Vk1J4HX7WvEP5Cm+iXPE8ixo7OM7gAO3/OKpQ==",
       "dev": true,
       "requires": {
-        "ignore": "^3.3.6",
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^5.0.2",
         "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "^5.4.1"
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.4.tgz",
+          "integrity": "sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz",
+      "integrity": "sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz",
+      "integrity": "sha512-Si16O0+Hqz1gDHsys6RtFRrW7cCTB6P7p3OJmKp3Y3dxpQE2qwOA7d3xnV+0mBmrPoi0RBnxlCKvqu70te6wjg==",
       "dev": true
     },
     "eslint-plugin-standard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
-      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
       "dev": true
     },
     "eslint-scope": {
@@ -4378,6 +4336,12 @@
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-glob": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.3.tgz",
@@ -4513,16 +4477,22 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.1.tgz",
+      "integrity": "sha512-BUaXPScuox3BPmS9CGqbsh7tvAGzBEU2Dlnw243WoHjC0vO57faTOvHOkPQkPZZdpvJuwOQhMdAQx3BtdUh6nQ==",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
+        "del": "^3.0.0",
+        "flatted": "^2.0.0",
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
       }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
     },
     "flush-write-stream": {
       "version": "1.0.3",
@@ -7265,12 +7235,6 @@
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
     },
-    "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
-      "dev": true
-    },
     "lodash.padleft": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.3.tgz",
@@ -7321,12 +7285,6 @@
       "requires": {
         "lodash._reinterpolate": "~3.0.0"
       }
-    },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
     },
     "log4js": {
       "version": "2.11.0",
@@ -7542,64 +7500,6 @@
         }
       }
     },
-    "loglevel": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz",
-      "integrity": "sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=",
-      "dev": true
-    },
-    "loglevel-colored-level-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz",
-      "integrity": "sha1-akAhj9x64V/HbD0PPmdsRlOIYD4=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "loglevel": "^1.4.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
@@ -7723,15 +7623,6 @@
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
         "ssri": "^6.0.0"
-      }
-    },
-    "make-plural": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-4.3.0.tgz",
-      "integrity": "sha512-xTYd4JVHpSCW+aqDof6w/MebaMVNTVYBZhbB/vi513xXdiPT92JMVCo0Jq8W2UZnzYRFeVbQiQ+I25l13JuKvA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
       }
     },
     "map-age-cleaner": {
@@ -7907,41 +7798,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
       "integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
-    },
-    "messageformat": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/messageformat/-/messageformat-1.1.1.tgz",
-      "integrity": "sha512-Q0uXcDtF5pEZsVSyhzDOGgZZK6ykN79VY9CwU3Nv0gsqx62BjdJW0MT+63UkHQ4exe3HE33ZlxR2/YwoJarRTg==",
-      "dev": true,
-      "requires": {
-        "glob": "~7.0.6",
-        "make-plural": "^4.1.1",
-        "messageformat-parser": "^1.1.0",
-        "nopt": "~3.0.6",
-        "reserved-words": "^0.1.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "messageformat-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-1.1.0.tgz",
-      "integrity": "sha512-Hwem6G3MsKDLS1FtBRGIs8T50P1Q00r3srS6QJePCFbad9fq0nYxwf3rnU2BreApRGhmpKMV7oZI06Sy1c9TPA==",
-      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -11358,612 +11214,13 @@
       "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
       "dev": true
     },
-    "prettier-eslint": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-8.8.2.tgz",
-      "integrity": "sha512-2UzApPuxi2yRoyMlXMazgR6UcH9DKJhNgCviIwY3ixZ9THWSSrUww5vkiZ3C48WvpFl1M1y/oU63deSy1puWEA==",
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "common-tags": "^1.4.0",
-        "dlv": "^1.1.0",
-        "eslint": "^4.0.0",
-        "indent-string": "^3.2.0",
-        "lodash.merge": "^4.6.0",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "prettier": "^1.7.0",
-        "pretty-format": "^23.0.1",
-        "require-relative": "^0.8.7",
-        "typescript": "^2.5.1",
-        "typescript-eslint-parser": "^16.0.0",
-        "vue-eslint-parser": "^2.0.2"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-          "dev": true,
-          "requires": {
-            "acorn": "^3.0.4"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-              "dev": true
-            }
-          }
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "eslint": {
-          "version": "4.19.1",
-          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.3.0",
-            "babel-code-frame": "^6.22.0",
-            "chalk": "^2.1.0",
-            "concat-stream": "^1.6.0",
-            "cross-spawn": "^5.1.0",
-            "debug": "^3.1.0",
-            "doctrine": "^2.1.0",
-            "eslint-scope": "^3.7.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^3.5.4",
-            "esquery": "^1.0.0",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
-            "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.0.1",
-            "ignore": "^3.3.3",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^3.0.6",
-            "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.9.1",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
-            "pluralize": "^7.0.0",
-            "progress": "^2.0.0",
-            "regexpp": "^1.0.1",
-            "require-uncached": "^1.0.3",
-            "semver": "^5.3.0",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "~2.0.1",
-            "table": "4.0.2",
-            "text-table": "~0.2.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "espree": {
-          "version": "3.5.4",
-          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-          "dev": true,
-          "requires": {
-            "acorn": "^5.5.0",
-            "acorn-jsx": "^3.0.0"
-          }
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "regexpp": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-          "dev": true
-        },
-        "table": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.2.3",
-            "ajv-keywords": "^2.1.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
-            "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
-          }
-        }
-      }
-    },
-    "prettier-eslint-cli": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/prettier-eslint-cli/-/prettier-eslint-cli-4.7.1.tgz",
-      "integrity": "sha512-hQbsGaEVz97oBBcKdsJ46khv0kOGkMyWrXzcFOXW6X8UuetZ/j0yDJkNJgUTVc6PVFbbzBXk+qgd5vos9qzXPQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "babel-runtime": "^6.23.0",
-        "boolify": "^1.0.0",
-        "camelcase-keys": "^4.1.0",
-        "chalk": "2.3.0",
-        "common-tags": "^1.4.0",
-        "eslint": "^4.5.0",
-        "find-up": "^2.1.0",
-        "get-stdin": "^5.0.1",
-        "glob": "^7.1.1",
-        "ignore": "^3.2.7",
-        "indent-string": "^3.1.0",
-        "lodash.memoize": "^4.1.2",
-        "loglevel-colored-level-prefix": "^1.0.0",
-        "messageformat": "^1.0.2",
-        "prettier-eslint": "^8.5.0",
-        "rxjs": "^5.3.0",
-        "yargs": "10.0.3"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-          "dev": true,
-          "requires": {
-            "acorn": "^3.0.4"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-              "dev": true
-            }
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.1.0",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
-          }
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
-        },
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "eslint": {
-          "version": "4.19.1",
-          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
-          "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.3.0",
-            "babel-code-frame": "^6.22.0",
-            "chalk": "^2.1.0",
-            "concat-stream": "^1.6.0",
-            "cross-spawn": "^5.1.0",
-            "debug": "^3.1.0",
-            "doctrine": "^2.1.0",
-            "eslint-scope": "^3.7.1",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^3.5.4",
-            "esquery": "^1.0.0",
-            "esutils": "^2.0.2",
-            "file-entry-cache": "^2.0.0",
-            "functional-red-black-tree": "^1.0.1",
-            "glob": "^7.1.2",
-            "globals": "^11.0.1",
-            "ignore": "^3.3.3",
-            "imurmurhash": "^0.1.4",
-            "inquirer": "^3.0.6",
-            "is-resolvable": "^1.0.0",
-            "js-yaml": "^3.9.1",
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "levn": "^0.3.0",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.2",
-            "mkdirp": "^0.5.1",
-            "natural-compare": "^1.4.0",
-            "optionator": "^0.8.2",
-            "path-is-inside": "^1.0.2",
-            "pluralize": "^7.0.0",
-            "progress": "^2.0.0",
-            "regexpp": "^1.0.1",
-            "require-uncached": "^1.0.3",
-            "semver": "^5.3.0",
-            "strip-ansi": "^4.0.0",
-            "strip-json-comments": "~2.0.1",
-            "table": "4.0.2",
-            "text-table": "~0.2.0"
-          }
-        },
-        "eslint-scope": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "espree": {
-          "version": "3.5.4",
-          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-          "dev": true,
-          "requires": {
-            "acorn": "^5.5.0",
-            "acorn-jsx": "^3.0.0"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "get-stdin": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-          "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "inquirer": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.4",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx-lite": "^4.0.8",
-            "rx-lite-aggregates": "^4.0.8",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lodash.memoize": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-          "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-          "dev": true,
-          "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "regexpp": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
-          "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-          "dev": true
-        },
-        "rxjs": {
-          "version": "5.5.12",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-          "dev": true,
-          "requires": {
-            "symbol-observable": "1.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        },
-        "table": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-          "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.2.3",
-            "ajv-keywords": "^2.1.0",
-            "chalk": "^2.1.0",
-            "lodash": "^4.17.4",
-            "slice-ansi": "1.0.0",
-            "string-width": "^2.1.1"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "10.0.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-          "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^8.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
-      }
-    },
-    "pretty-format": {
-      "version": "23.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
+        "fast-diff": "^1.1.2"
       }
     },
     "process": {
@@ -12409,6 +11666,34 @@
         "readdir-scoped-modules": "^1.0.0"
       }
     },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "read-pkg-up": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
@@ -12461,32 +11746,6 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
         }
       }
     },
@@ -12562,12 +11821,6 @@
       "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=",
       "dev": true,
       "optional": true
-    },
-    "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -12708,12 +11961,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
-    "require-relative": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-      "dev": true
-    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -12728,12 +11975,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
-    },
-    "reserved-words": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
-      "integrity": "sha1-AKCUD5jNUBrqqsMWQR2a3FKzGrE=",
       "dev": true
     },
     "resolve": {
@@ -12851,21 +12092,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
       "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "*"
-      }
     },
     "rxjs": {
       "version": "6.3.3",
@@ -13778,12 +13004,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
-    },
     "syntax-error": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
@@ -14161,30 +13381,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
-    },
-    "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
-      "dev": true
-    },
-    "typescript-eslint-parser": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz",
-      "integrity": "sha512-IKawLTu4A2xN3aN/cPLxvZ0bhxZHILGDKTZWvWNJ3sLNhJ3PjfMEDQmR2VMpdRPrmWOadgWXRwjLBzSA8AGsaQ==",
-      "dev": true,
-      "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-          "dev": true
-        }
-      }
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -14570,65 +13766,6 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
-    },
-    "vue-eslint-parser": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
-      "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.1.0",
-        "eslint-scope": "^3.7.1",
-        "eslint-visitor-keys": "^1.0.0",
-        "espree": "^3.5.2",
-        "esquery": "^1.0.0",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-          "dev": true,
-          "requires": {
-            "acorn": "^3.0.4"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "3.3.0",
-              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-              "dev": true
-            }
-          }
-        },
-        "eslint-scope": {
-          "version": "3.7.3",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
-          "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        },
-        "espree": {
-          "version": "3.5.4",
-          "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-          "dev": true,
-          "requires": {
-            "acorn": "^5.5.0",
-            "acorn-jsx": "^3.0.0"
-          }
-        }
-      }
     },
     "watchify": {
       "version": "3.11.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "nyc report --reporter=lcov",
     "integration:server": "lerna run integration:server --parallel",
     "lint": "eslint '**/*.js'",
-    "format": "prettier-eslint --write '**/*.js'",
+    "format": "prettier --ignore-path .eslintignore --write '**/*.js'",
     "docs": "lerna run docs",
     "example": "lerna run example",
     "prebump": "npm run test",
@@ -24,34 +24,6 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  },
-  "eslintConfig": {
-    "extends": [
-      "standard"
-    ],
-    "plugins": [
-      "standard"
-    ],
-    "rules": {
-      "array-bracket-spacing": [
-        "error",
-        "never"
-      ],
-      "object-curly-spacing": [
-        "error",
-        "never"
-      ]
-    },
-    "overrides": [
-      {
-        "files": [
-          "**/*test.js"
-        ],
-        "env": {
-          "mocha": true
-        }
-      }
-    ]
   },
   "nyc": {
     "all": true,
@@ -75,12 +47,14 @@
     "cross-env": "^5.1.4",
     "cz-conventional-changelog": "^2.1.0",
     "debug": "^3.1.0",
-    "eslint": "^5.0.1",
-    "eslint-config-standard": "^11.0.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-standard": "^3.1.0",
+    "eslint": "^5.8.0",
+    "eslint-config-prettier": "^3.1.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-prettier": "^3.0.0",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "express": "^4.16.2",
     "karma": "^2.0.0",
     "karma-browserify": "^5.1.3",
@@ -92,7 +66,7 @@
     "mocha": "^5.0.0",
     "nyc": "^12.0.2",
     "pify": "^4.0.1",
-    "prettier-eslint-cli": "^4.7.0",
+    "prettier": "^1.14.3",
     "proxyquire": "^2.0.1",
     "proxyquire-universal": "^1.0.8",
     "proxyquireify": "^3.2.1",

--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -22,14 +22,14 @@ const resolve = require('./resolve')
 const writeFile = util.promisify(fs.writeFile)
 const stackup = util.promisify(pcbStackup)
 
-module.exports = function cli (processArgv, config) {
+module.exports = function cli(processArgv, config) {
   const argv = yargs
     .usage('$0 [options] <files...>', `${description}\nv${version}`, yargs => {
       yargs.positional('files', {
         coerce: files => files.map(resolve),
         describe:
           "Filenames, directories, or globs to a PCB's Gerber/drill files",
-        type: 'string'
+        type: 'string',
       })
 
       examples.forEach(e => yargs.example(e.cmd, e.desc))
@@ -58,7 +58,7 @@ module.exports = function cli (processArgv, config) {
     .then(renderFiles)
     .then(writeRenders)
 
-  function renderFiles (filenames) {
+  function renderFiles(filenames) {
     const layers = filenames.map(makeLayerFromFilename).filter(_ => _)
 
     if (!layers.length) throw new Error(`No valid Gerber or drill files found`)
@@ -66,7 +66,7 @@ module.exports = function cli (processArgv, config) {
     return stackup(layers, argv.board)
   }
 
-  function makeLayerFromFilename (filename) {
+  function makeLayerFromFilename(filename) {
     const basename = path.basename(filename)
     const type = getType(basename)
 
@@ -85,19 +85,19 @@ module.exports = function cli (processArgv, config) {
     return {type, gerber, options, filename: basename}
   }
 
-  function getType (basename) {
+  function getType(basename) {
     const defaultType = whatsThatGerber(basename)
 
     return get(argv.layer, `${basename}.type`, defaultType)
   }
 
-  function getOptions (basename, type) {
+  function getOptions(basename, type) {
     const defaultOptions = type === 'drl' ? argv.drill : argv.gerber
 
     return get(argv.layer, `${basename}.options`, defaultOptions)
   }
 
-  function writeRenders (stackup) {
+  function writeRenders(stackup) {
     const name = inferBoardName(stackup)
     const ensureDir =
       argv.out !== options.out.STDOUT ? makeDir(argv.out) : Promise.resolve()
@@ -113,12 +113,12 @@ module.exports = function cli (processArgv, config) {
               `${layer.filename}.${layer.type}.svg`,
               gerberToSvg.render(layer.converter, layer.options.attributes)
             )
-          )
+          ),
       ])
     )
   }
 
-  function writeOutput (name, contents) {
+  function writeOutput(name, contents) {
     if (argv.out === options.out.STDOUT) return console.log(contents)
 
     const filename = path.join(argv.out, name)
@@ -127,7 +127,7 @@ module.exports = function cli (processArgv, config) {
   }
 }
 
-function inferBoardName (stackup) {
+function inferBoardName(stackup) {
   const names = stackup.layers.map(ly =>
     path.basename(ly.filename, path.extname(ly.filename))
   )

--- a/packages/cli/lib/examples.js
+++ b/packages/cli/lib/examples.js
@@ -5,11 +5,11 @@ const options = require('./options')
 module.exports = [
   {
     cmd: '$0',
-    desc: 'Render files in `cwd` and output to `cwd`'
+    desc: 'Render files in `cwd` and output to `cwd`',
   },
   {
     cmd: '$0 --out=-',
-    desc: 'Render files in `cwd` and output to `stdout`'
+    desc: 'Render files in `cwd` and output to `stdout`',
   },
-  ...Object.keys(options).map(name => options[name].example)
+  ...Object.keys(options).map(name => options[name].example),
 ]

--- a/packages/cli/lib/options.js
+++ b/packages/cli/lib/options.js
@@ -14,8 +14,8 @@ module.exports = {
     type: 'string',
     example: {
       cmd: '$0 --out=renders',
-      desc: 'Write SVGs into directory `./renders`'
-    }
+      desc: 'Write SVGs into directory `./renders`',
+    },
   },
   noBoard: {
     alias: 'B',
@@ -23,8 +23,8 @@ module.exports = {
     type: 'boolean',
     example: {
       cmd: '$0 -B',
-      desc: 'Output only the individual layer renders'
-    }
+      desc: 'Output only the individual layer renders',
+    },
   },
   noLayer: {
     alias: 'L',
@@ -32,8 +32,8 @@ module.exports = {
     type: 'boolean',
     example: {
       cmd: '$0 -L',
-      desc: 'Output only the top and bottom PCB renders'
-    }
+      desc: 'Output only the top and bottom PCB renders',
+    },
   },
   force: {
     alias: 'f',
@@ -41,8 +41,8 @@ module.exports = {
     type: 'boolean',
     example: {
       cmd: '$0 -B --force some-file.xyz',
-      desc: 'Attempt render even if whats-that-gerber cannot identify'
-    }
+      desc: 'Attempt render even if whats-that-gerber cannot identify',
+    },
   },
   gerber: {
     alias: 'g',
@@ -50,8 +50,8 @@ module.exports = {
     type: 'object',
     example: {
       cmd: '$0 -B -g.attributes.color=blue',
-      desc: 'Set the color attribute of all Gerber SVGs'
-    }
+      desc: 'Set the color attribute of all Gerber SVGs',
+    },
   },
   drill: {
     alias: 'd',
@@ -59,8 +59,8 @@ module.exports = {
     type: 'object',
     example: {
       cmd: '$0 -B -d.attributes.color=red',
-      desc: 'Set the color attribute of all drill SVGs'
-    }
+      desc: 'Set the color attribute of all drill SVGs',
+    },
   },
   board: {
     alias: 'b',
@@ -68,8 +68,8 @@ module.exports = {
     type: 'object',
     example: {
       cmd: '$0 -b.color.sm="rgba(128,00,00,0.75)"',
-      desc: 'Set the soldermask color of the board renders'
-    }
+      desc: 'Set the soldermask color of the board renders',
+    },
   },
   layer: {
     alias: 'l',
@@ -81,8 +81,8 @@ module.exports = {
       desc:
         'Set layer type of `arduino-uno.drd` to `drill` and parse as a drill file',
       aside:
-        "If you're using this option a lot, you may want to consider using a config file"
-    }
+        "If you're using this option a lot, you may want to consider using a config file",
+    },
   },
   quiet: {
     alias: 'q',
@@ -90,7 +90,7 @@ module.exports = {
     type: 'boolean',
     example: {
       cmd: '$0 --quiet',
-      desc: 'Do not print info to stderr'
-    }
-  }
+      desc: 'Do not print info to stderr',
+    },
+  },
 }

--- a/packages/cli/lib/resolve.js
+++ b/packages/cli/lib/resolve.js
@@ -3,6 +3,6 @@
 const path = require('path')
 const untildify = require('untildify')
 
-module.exports = function resolve (filename) {
+module.exports = function resolve(filename) {
   return path.resolve(process.cwd(), untildify(filename))
 }

--- a/packages/cli/scripts/docs.js
+++ b/packages/cli/scripts/docs.js
@@ -36,18 +36,18 @@ readFile(doc, 'utf8')
     }
   )
 
-function insertOptionsIntoDocument (contents) {
+function insertOptionsIntoDocument(contents) {
   return contents.replace(
     matcher('options'),
     (match, startTag, endTag) => `${startTag}${generateOptions()}${endTag}`
   )
 }
 
-function writeDocs (contents) {
+function writeDocs(contents) {
   return writeFile(doc, contents, 'utf8')
 }
 
-function generateOptions () {
+function generateOptions() {
   return Object.keys(options)
     .map(long => {
       const {
@@ -55,7 +55,7 @@ function generateOptions () {
         type,
         example,
         alias: short,
-        default: defaultValue
+        default: defaultValue,
       } = options[long]
 
       return `
@@ -73,7 +73,7 @@ ${example.cmd.replace('$0', 'tracespace')}
     .join('\n')
 }
 
-function getDefaultFromType (type) {
+function getDefaultFromType(type) {
   switch (type) {
     case 'boolean':
       return 'false'

--- a/packages/fixtures/index.js
+++ b/packages/fixtures/index.js
@@ -16,10 +16,10 @@ module.exports = {
   gerberFilenames,
   getBoards,
   getGerberSpecs,
-  server
+  server,
 }
 
-function getBoards (done) {
+function getBoards(done) {
   runWaterfall(
     [
       next => glob(GLOB_BOARD_MANIFEST, next),
@@ -27,19 +27,19 @@ function getBoards (done) {
         runParallel(
           manifestPaths.map(manifest => next => readManifest(manifest, next)),
           next
-        )
+        ),
     ],
     done
   )
 }
 
-getBoards.sync = function getBoardsSync () {
+getBoards.sync = function getBoardsSync() {
   const manifests = glob.sync(GLOB_BOARD_MANIFEST)
 
   return manifests.map(manifest => readManifest.sync(manifest))
 }
 
-function getGerberSpecs (done) {
+function getGerberSpecs(done) {
   runWaterfall(
     [
       next => glob(GLOB_SPEC_GERBER, next),
@@ -48,20 +48,20 @@ function getGerberSpecs (done) {
           gerberPaths.map(gerber => next => readFile(gerber, {}, next)),
           next
         ),
-      (gerberSpecs, next) => next(null, collectSpecs(gerberSpecs))
+      (gerberSpecs, next) => next(null, collectSpecs(gerberSpecs)),
     ],
     done
   )
 }
 
-getGerberSpecs.sync = function () {
+getGerberSpecs.sync = function() {
   const paths = glob.sync(GLOB_SPEC_GERBER)
   const specs = paths.map(filepath => readFile.sync(filepath, {}))
 
   return collectSpecs(specs)
 }
 
-function readManifest (manifestPath, done) {
+function readManifest(manifestPath, done) {
   const name = path.basename(path.dirname(manifestPath))
 
   runWaterfall(
@@ -70,18 +70,18 @@ function readManifest (manifestPath, done) {
   )
 }
 
-readManifest.sync = function readManifestSync (manifestPath) {
+readManifest.sync = function readManifestSync(manifestPath) {
   const name = path.basename(path.dirname(manifestPath))
   const manifest = readFile.sync(manifestPath, {name})
 
   return addLayersToManifest.sync(manifest)
 }
 
-function getLayerFilepath (manifest, layer) {
+function getLayerFilepath(manifest, layer) {
   return path.join(path.dirname(manifest.filepath), layer.name)
 }
 
-function addLayersToManifest (manifest, done) {
+function addLayersToManifest(manifest, done) {
   runWaterfall(
     [
       next =>
@@ -91,13 +91,13 @@ function addLayersToManifest (manifest, done) {
           ),
           next
         ),
-      (layers, next) => next(null, Object.assign(manifest, {layers}))
+      (layers, next) => next(null, Object.assign(manifest, {layers})),
     ],
     done
   )
 }
 
-addLayersToManifest.sync = function addLayersToManifestSync (manifest) {
+addLayersToManifest.sync = function addLayersToManifestSync(manifest) {
   const layers = manifest.layers.map(layer =>
     readFile.sync(getLayerFilepath(manifest, layer), layer)
   )
@@ -105,23 +105,23 @@ addLayersToManifest.sync = function addLayersToManifestSync (manifest) {
   return Object.assign(manifest, {layers})
 }
 
-function readFile (filepath, props, done) {
+function readFile(filepath, props, done) {
   runWaterfall(
     [
       next => fs.readFile(filepath, 'utf8', next),
-      (source, next) => next(null, makeFileResult(filepath, props, source))
+      (source, next) => next(null, makeFileResult(filepath, props, source)),
     ],
     done
   )
 }
 
-readFile.sync = function readFileSync (filepath, props) {
+readFile.sync = function readFileSync(filepath, props) {
   const source = fs.readFileSync(filepath, 'utf8')
 
   return makeFileResult(filepath, props, source)
 }
 
-function makeFileResult (filepath, props, source) {
+function makeFileResult(filepath, props, source) {
   const dirname = path.dirname(filepath)
   const category = path.basename(dirname)
   const extname = path.extname(filepath)
@@ -134,7 +134,7 @@ function makeFileResult (filepath, props, source) {
   return Object.assign(file, result, props)
 }
 
-function collectSpecs (gerberSpecs) {
+function collectSpecs(gerberSpecs) {
   const {suites, suitesByName} = gerberSpecs.reduce(
     (result, spec) => {
       const {category, name} = spec
@@ -148,7 +148,7 @@ function collectSpecs (gerberSpecs) {
         result.suitesByName[category] = {
           name: category,
           specs: [name],
-          specsByName: {[name]: spec}
+          specsByName: {[name]: spec},
         }
       } else if (result.suitesByName[category].specs.indexOf(name) < 0) {
         result.suitesByName[category].specs.push(name)
@@ -169,6 +169,6 @@ function collectSpecs (gerberSpecs) {
     name,
     specs: suitesByName[name].specs.map(
       specName => suitesByName[name].specsByName[specName]
-    )
+    ),
   }))
 }

--- a/packages/fixtures/server/index.js
+++ b/packages/fixtures/server/index.js
@@ -10,7 +10,7 @@ const debug = require('debug')('tracespace/fixtures/server')
 
 const TEMPLATE = path.join(__dirname, './template.html')
 
-module.exports = function makeServer (name, getSuites, getSuiteResult) {
+module.exports = function makeServer(name, getSuites, getSuiteResult) {
   const app = express()
 
   app.get('/', (request, response) => {
@@ -28,11 +28,11 @@ module.exports = function makeServer (name, getSuites, getSuiteResult) {
 
   return app
 
-  function handleTestRun (done) {
+  function handleTestRun(done) {
     runWaterfall([getSuites, getResults, makeResponse], done)
   }
 
-  function getResults (suites, done) {
+  function getResults(suites, done) {
     debug(`Rendering specs from ${suites.length} suites`)
 
     const tasks = suites.map(suite => next => getSuiteResult(suite, next))
@@ -40,14 +40,14 @@ module.exports = function makeServer (name, getSuites, getSuiteResult) {
     runParallel(tasks, done)
   }
 
-  function makeResponse (results, done) {
+  function makeResponse(results, done) {
     debug(`Running template with ${results.length} suites`)
 
     runTemplate({name, results}, done)
   }
 }
 
-function runTemplate (props, done) {
+function runTemplate(props, done) {
   runWaterfall(
     [
       next => fs.readFile(TEMPLATE, 'utf8', next),
@@ -57,7 +57,7 @@ function runTemplate (props, done) {
         } catch (error) {
           next(error)
         }
-      }
+      },
     ],
     done
   )

--- a/packages/gerber-parser/lib/_commands.js
+++ b/packages/gerber-parser/lib/_commands.js
@@ -1,27 +1,27 @@
 // factories to generate all possible parsed by a gerber command
 'use strict'
 
-var done = function (line) {
+var done = function(line) {
   return {type: 'done', line: line || -1}
 }
 
-var set = function (property, value, line) {
+var set = function(property, value, line) {
   return {type: 'set', line: line || -1, prop: property, value: value}
 }
 
-var level = function (level, value, line) {
+var level = function(level, value, line) {
   return {type: 'level', line: line || -1, level: level, value: value}
 }
 
-var tool = function (code, tool, line) {
+var tool = function(code, tool, line) {
   return {type: 'tool', line: line || -1, code: code, tool: tool}
 }
 
-var op = function (operation, location, line) {
+var op = function(operation, location, line) {
   return {type: 'op', line: line || -1, op: operation, coord: location}
 }
 
-var macro = function (name, blocks, line) {
+var macro = function(name, blocks, line) {
   return {type: 'macro', line: line || -1, name: name, blocks: blocks}
 }
 
@@ -31,6 +31,6 @@ var commandMap = {
   level: level,
   tool: tool,
   op: op,
-  macro: macro
+  macro: macro,
 }
 module.exports = commandMap

--- a/packages/gerber-parser/lib/_determine-filetype.js
+++ b/packages/gerber-parser/lib/_determine-filetype.js
@@ -1,7 +1,7 @@
 // function to determine filetype from a chunk
 'use strict'
 
-var determine = function (chunk, start, LIMIT) {
+var determine = function(chunk, start, LIMIT) {
   var limit = Math.min(LIMIT - start, chunk.length)
   var current = []
   var filetype = null

--- a/packages/gerber-parser/lib/_drill-mode.js
+++ b/packages/gerber-parser/lib/_drill-mode.js
@@ -6,5 +6,5 @@ module.exports = {
   MOVE: '0',
   LINEAR: '1',
   CW_ARC: '2',
-  CCW_ARC: '3'
+  CCW_ARC: '3',
 }

--- a/packages/gerber-parser/lib/_parse-drill.js
+++ b/packages/gerber-parser/lib/_parse-drill.js
@@ -18,7 +18,7 @@ var RE_TOOL_SET = /T0*(\d+)(?![\S]*C)/
 var RE_COORD = /((?:[XYIJA][+-]?[\d.]+){1,4})(?:G85((?:[XY][+-]?[\d.]+){1,2}))?/
 var RE_ROUTE = /^G0([01235])/
 
-var setUnits = function (parser, units, line) {
+var setUnits = function(parser, units, line) {
   var format = units === 'in' ? [2, 4] : [3, 3]
   if (!parser.format.places) {
     parser.format.places = format
@@ -26,7 +26,7 @@ var setUnits = function (parser, units, line) {
   return parser._push(commands.set('units', units, line))
 }
 
-var parseCommentForFormatHints = function (parser, block, line) {
+var parseCommentForFormatHints = function(parser, block, line) {
   var result = {}
 
   if (RE_KI_HINT.test(block)) {
@@ -74,7 +74,7 @@ var parseCommentForFormatHints = function (parser, block, line) {
   return result
 }
 
-var zeroFromSupression = function (suppression) {
+var zeroFromSupression = function(suppression) {
   if (suppression === 'T') {
     return 'L'
   } else if (suppression === 'L') {
@@ -82,7 +82,7 @@ var zeroFromSupression = function (suppression) {
   }
 }
 
-var parseUnits = function (parser, block, line) {
+var parseUnits = function(parser, block, line) {
   var unitsMatch = block.match(RE_UNITS)
   var units = unitsMatch[1]
   var suppression = unitsMatch[2]
@@ -98,7 +98,7 @@ var parseUnits = function (parser, block, line) {
   }
 }
 
-var coordToCommand = function (parser, block, line) {
+var coordToCommand = function(parser, block, line) {
   var coordMatch = block.match(RE_COORD)
   var coord = parseCoord.parse(coordMatch[1], parser.format)
 
@@ -137,7 +137,7 @@ var coordToCommand = function (parser, block, line) {
   }
 }
 
-var parseBlock = function (parser, block, line) {
+var parseBlock = function(parser, block, line) {
   if (RE_TOOL_DEF.test(block)) {
     var toolMatch = block.match(RE_TOOL_DEF)
     var toolCode = toolMatch[1]
@@ -190,9 +190,9 @@ var parseBlock = function (parser, block, line) {
   }
 }
 
-var flush = function (parser) {
+var flush = function(parser) {
   if (parser._drillStash.length) {
-    parser._drillStash.forEach(function (data) {
+    parser._drillStash.forEach(function(data) {
       if (!parser.format.zero && RE_COORD.test(data.block)) {
         parser.format.zero = 'T'
         parser._warn(
@@ -206,7 +206,7 @@ var flush = function (parser) {
   }
 }
 
-var parse = function (parser, block) {
+var parse = function(parser, block) {
   parser._drillStash = parser._drillStash || []
 
   // parse comments for formatting hints and ignore the rest
@@ -214,7 +214,7 @@ var parse = function (parser, block) {
     // check for kicad format hints
     var formatHints = parseCommentForFormatHints(parser, block, parser.line)
 
-    Object.keys(formatHints).forEach(function (key) {
+    Object.keys(formatHints).forEach(function(key) {
       if (!parser.format[key]) {
         parser.format[key] = formatHints[key]
       }

--- a/packages/gerber-parser/lib/_parse-gerber.js
+++ b/packages/gerber-parser/lib/_parse-gerber.js
@@ -31,7 +31,7 @@ var RE_STEP_REP = /^%SR(?:X(\d+)Y(\d+)I([\d.]+)J([\d.]+))?/
 var RE_TOOL_DEF = /^%ADD0*(\d{2,})([A-Za-z_$][\w\-.]*)(?:,((?:X?[\d.]+)*))?/
 var RE_MACRO = /^%AM([A-Za-z_$][\w\-.]*)\*?(.*)/
 
-var parseToolDef = function (parser, block) {
+var parseToolDef = function(parser, block) {
   var format = {places: parser.format.places}
   var toolMatch = block.match(RE_TOOL_DEF)
   var tool = toolMatch[1]
@@ -76,7 +76,7 @@ var parseToolDef = function (parser, block) {
   if (toolArgs[maxArgs - 1]) {
     hole = [
       normalize(toolArgs[maxArgs - 2], format),
-      normalize(toolArgs[maxArgs - 1], format)
+      normalize(toolArgs[maxArgs - 1], format),
     ]
   } else if (toolArgs[maxArgs - 2]) {
     hole = [normalize(toolArgs[maxArgs - 2], format)]
@@ -85,21 +85,21 @@ var parseToolDef = function (parser, block) {
   return parser._push(commands.tool(tool, toolDef))
 }
 
-var parseMacroDef = function (parser, block) {
+var parseMacroDef = function(parser, block) {
   var macroMatch = block.match(RE_MACRO)
   var name = macroMatch[1]
   if (name.match(/-/)) {
     parser._warn('hyphens in macro name are illegal: ' + name)
   }
   var blockMatch = macroMatch[2].length ? macroMatch[2].split('*') : []
-  var blocks = blockMatch.filter(Boolean).map(function (block) {
+  var blocks = blockMatch.filter(Boolean).map(function(block) {
     return parseMacroBlock(parser, block)
   })
 
   return parser._push(commands.macro(name, blocks))
 }
 
-var parse = function (parser, block) {
+var parse = function(parser, block) {
   if (RE_COMMENT.test(block)) {
     return
   }

--- a/packages/gerber-parser/lib/_parse-macro-block.js
+++ b/packages/gerber-parser/lib/_parse-macro-block.js
@@ -6,7 +6,7 @@ var parseMacroExpr = require('./_parse-macro-expression')
 var RE_NUM = /^-?[\d.]+$/
 var RE_VAR_DEF = /^(\$[\d+])=(.+)/
 
-var parseMacroBlock = function (parser, block) {
+var parseMacroBlock = function(parser, block) {
   // check first for a comment
   if (block[0] === '0') {
     return {type: 'comment'}
@@ -19,7 +19,7 @@ var parseMacroBlock = function (parser, block) {
     var varExpr = varDefMatch[2]
     var evaluate = parseMacroExpr(parser, varExpr)
 
-    var setMods = function (mods) {
+    var setMods = function(mods) {
       mods[varName] = evaluate(mods)
 
       return mods
@@ -28,7 +28,7 @@ var parseMacroBlock = function (parser, block) {
   }
 
   // map a primitive param to a number or, if an expression, a function
-  var modVal = function (m) {
+  var modVal = function(m) {
     if (RE_NUM.test(m)) {
       return Number(m)
     }
@@ -48,7 +48,7 @@ var parseMacroBlock = function (parser, block) {
       cx: mods[3],
       cy: mods[4],
       // handle optional rotation with circle primitives
-      rot: mods[5] || 0
+      rot: mods[5] || 0,
     }
   }
 
@@ -66,7 +66,7 @@ var parseMacroBlock = function (parser, block) {
       y1: mods[4],
       x2: mods[5],
       y2: mods[6],
-      rot: mods[7]
+      rot: mods[7],
     }
   }
 
@@ -79,7 +79,7 @@ var parseMacroBlock = function (parser, block) {
       height: mods[3],
       cx: mods[4],
       cy: mods[5],
-      rot: mods[6]
+      rot: mods[6],
     }
   }
 
@@ -94,7 +94,7 @@ var parseMacroBlock = function (parser, block) {
       height: mods[3],
       x: mods[4],
       y: mods[5],
-      rot: mods[6]
+      rot: mods[6],
     }
   }
 
@@ -103,7 +103,7 @@ var parseMacroBlock = function (parser, block) {
       type: 'outline',
       exp: exp,
       points: mods.slice(3, -1).map(Number),
-      rot: Number(mods[mods.length - 1])
+      rot: Number(mods[mods.length - 1]),
     }
   }
 
@@ -115,7 +115,7 @@ var parseMacroBlock = function (parser, block) {
       cx: mods[3],
       cy: mods[4],
       dia: mods[5],
-      rot: mods[6]
+      rot: mods[6],
     }
   }
 
@@ -132,7 +132,7 @@ var parseMacroBlock = function (parser, block) {
       maxRings: mods[6],
       crossThx: mods[7],
       crossLen: mods[8],
-      rot: mods[9]
+      rot: mods[9],
     }
   }
 
@@ -146,7 +146,7 @@ var parseMacroBlock = function (parser, block) {
       outerDia: mods[3],
       innerDia: mods[4],
       gap: mods[5],
-      rot: mods[6]
+      rot: mods[6],
     }
   } else {
     parser._warn(code + ' is an unrecognized primitive for a macro aperture')

--- a/packages/gerber-parser/lib/_parse-macro-expression.js
+++ b/packages/gerber-parser/lib/_parse-macro-expression.js
@@ -5,7 +5,7 @@ var RE_OP = /[+\-/xX()]/
 var RE_NUMBER = /[$\d.]+/
 var RE_TOKEN = new RegExp([RE_OP.source, RE_NUMBER.source].join('|'), 'g')
 
-module.exports = function parseMacroExpression (parser, expr) {
+module.exports = function parseMacroExpression(parser, expr) {
   // tokenize the expression
   var tokens = expr.match(RE_TOKEN)
 
@@ -13,7 +13,7 @@ module.exports = function parseMacroExpression (parser, expr) {
   var parseExpression
 
   // primary tokens are numbers and parentheses
-  var parsePrimary = function () {
+  var parsePrimary = function() {
     var t = tokens.shift()
     var exp
 
@@ -27,7 +27,7 @@ module.exports = function parseMacroExpression (parser, expr) {
   }
 
   // parse multiplication and division tokens
-  var parseMultiplication = function () {
+  var parseMultiplication = function() {
     var exp = parsePrimary()
     var t = tokens[0]
 
@@ -45,7 +45,7 @@ module.exports = function parseMacroExpression (parser, expr) {
   }
 
   // parse addition and subtraction tokens
-  parseExpression = function () {
+  parseExpression = function() {
     var exp = parseMultiplication()
     var t = tokens[0]
     while (t === '+' || t === '-') {
@@ -61,8 +61,8 @@ module.exports = function parseMacroExpression (parser, expr) {
   var tree = parseExpression()
 
   // evalute by recursively traversing the tree
-  var evaluate = function (op, mods) {
-    var getValue = function (t) {
+  var evaluate = function(op, mods) {
+    var getValue = function(t) {
       if (t[0] === '$') {
         return Number(mods[t])
       }
@@ -87,7 +87,7 @@ module.exports = function parseMacroExpression (parser, expr) {
   }
 
   // return the evaluation function bound to the parsed expression tree
-  return function (mods) {
+  return function(mods) {
     return evaluate(tree, mods)
   }
 }

--- a/packages/gerber-parser/lib/_warning.js
+++ b/packages/gerber-parser/lib/_warning.js
@@ -1,7 +1,7 @@
 // simple warning class to be emitted when something questionable in the gerber is found
 'use strict'
 
-var warning = function (message, line) {
+var warning = function(message, line) {
   return {message: message, line: line}
 }
 

--- a/packages/gerber-parser/lib/get-next-block.js
+++ b/packages/gerber-parser/lib/get-next-block.js
@@ -2,7 +2,7 @@
 // returns {next: '_', read: [chars read], lines: [lines read]}
 'use strict'
 
-var getNext = function (type, chunk, start) {
+var getNext = function(type, chunk, start) {
   if (type !== 'gerber' && type !== 'drill') {
     throw new Error('filetype to get next block must be "drill" or "gerber"')
   }

--- a/packages/gerber-parser/lib/index.js
+++ b/packages/gerber-parser/lib/index.js
@@ -5,7 +5,7 @@ var isFinite = require('lodash.isfinite')
 
 var Parser = require('./parser')
 
-var verifyPlaces = function (p) {
+var verifyPlaces = function(p) {
   if (
     Array.isArray(p) &&
     p.length === 2 &&
@@ -17,7 +17,7 @@ var verifyPlaces = function (p) {
   throw new Error('places must be an array of two whole numbers')
 }
 
-var verifyZero = function (z) {
+var verifyZero = function(z) {
   if (z === 'T' || z === 'L') {
     return z
   }
@@ -25,7 +25,7 @@ var verifyZero = function (z) {
   throw new Error("zero suppression must be 'L' or 'T'")
 }
 
-var verifyFiletype = function (f) {
+var verifyFiletype = function(f) {
   if (f === 'gerber' || f === 'drill') {
     return f
   }
@@ -33,7 +33,7 @@ var verifyFiletype = function (f) {
   throw new Error('filetype must be "drill" or "gerber"')
 }
 
-module.exports = function (options) {
+module.exports = function(options) {
   options = options || {}
 
   var places = options.places ? verifyPlaces(options.places) : null

--- a/packages/gerber-parser/lib/normalize-coord.js
+++ b/packages/gerber-parser/lib/normalize-coord.js
@@ -7,7 +7,7 @@ var padLeft = require('lodash.padleft')
 var padRight = require('lodash.padright')
 
 // function takes in the number string to be converted and the format object
-var normalizeCoord = function (number, format) {
+var normalizeCoord = function(number, format) {
   // make sure we're dealing with a string
   if (number == null) {
     return NaN

--- a/packages/gerber-parser/lib/parse-coord.js
+++ b/packages/gerber-parser/lib/parse-coord.js
@@ -13,10 +13,10 @@ var MATCH = [
   {coord: 'y', test: /Y([+-]?[\d.]+)/},
   {coord: 'i', test: /I([+-]?[\d.]+)/},
   {coord: 'j', test: /J([+-]?[\d.]+)/},
-  {coord: 'a', test: /A([\d.]+)/}
+  {coord: 'a', test: /A([\d.]+)/},
 ]
 
-var parse = function (coord, format) {
+var parse = function(coord, format) {
   if (coord == null) {
     return {}
   }
@@ -26,7 +26,7 @@ var parse = function (coord, format) {
   }
 
   // pull out the x, y, i, and j
-  var parsed = MATCH.reduce(function (result, matcher) {
+  var parsed = MATCH.reduce(function(result, matcher) {
     var coordMatch = coord.match(matcher.test)
 
     if (coordMatch) {
@@ -39,7 +39,7 @@ var parse = function (coord, format) {
   return parsed
 }
 
-var detectZero = function (coord) {
+var detectZero = function(coord) {
   if (RE_LEADING.test(coord)) {
     return 'L'
   }

--- a/packages/gerber-parser/lib/parser.js
+++ b/packages/gerber-parser/lib/parser.js
@@ -14,7 +14,7 @@ var drillMode = require('./_drill-mode')
 
 var LIMIT = 65535
 
-var Parser = function (places, zero, filetype) {
+var Parser = function(places, zero, filetype) {
   Transform.call(this, {readableObjectMode: true})
 
   // parser properties
@@ -29,7 +29,7 @@ var Parser = function (places, zero, filetype) {
 
 inherits(Parser, Transform)
 
-Parser.prototype._process = function (chunk, filetype) {
+Parser.prototype._process = function(chunk, filetype) {
   while (this._index < chunk.length) {
     var next = getNext(filetype, chunk, this._index)
     this._index += next.read
@@ -46,7 +46,7 @@ Parser.prototype._process = function (chunk, filetype) {
   }
 }
 
-Parser.prototype._transform = function (chunk, encoding, done) {
+Parser.prototype._transform = function(chunk, encoding, done) {
   var filetype = this.format.filetype
 
   // decode buffer to string
@@ -78,7 +78,7 @@ Parser.prototype._transform = function (chunk, encoding, done) {
   done()
 }
 
-Parser.prototype._flush = function (done) {
+Parser.prototype._flush = function(done) {
   if (this.format.filetype === 'drill') {
     parseDrill.flush(this)
   }
@@ -86,7 +86,7 @@ Parser.prototype._flush = function (done) {
   return done && done()
 }
 
-Parser.prototype._push = function (data) {
+Parser.prototype._push = function(data) {
   if (data.line === -1) {
     data.line = this.line
   }
@@ -95,11 +95,11 @@ Parser.prototype._push = function (data) {
   pushTarget.push(data)
 }
 
-Parser.prototype._warn = function (message) {
+Parser.prototype._warn = function(message) {
   this.emit('warning', warning(message, this.line))
 }
 
-Parser.prototype.parseSync = function (file) {
+Parser.prototype.parseSync = function(file) {
   var filetype = determineFiletype(file, this._index, 100 * LIMIT)
   this.format.filetype = filetype
   this._syncResult = []

--- a/packages/gerber-parser/test/gerber-parser_drill_test.js
+++ b/packages/gerber-parser/test/gerber-parser_drill_test.js
@@ -7,13 +7,13 @@ var partial = require('lodash/partial')
 
 var parser = require('../lib')
 
-describe('gerber parser with gerber files', function () {
+describe('gerber parser with gerber files', function() {
   var p
   var pFactory = partial(parser, {filetype: 'drill'})
 
   // convenience function to expect an array of results
-  var expectResults = function (expected, done) {
-    var handleData = function (res) {
+  var expectResults = function(expected, done) {
+    var handleData = function(res) {
       expect(res).to.eql(expected.shift())
       if (!expected.length) {
         return done()
@@ -23,25 +23,25 @@ describe('gerber parser with gerber files', function () {
     p.on('data', handleData)
   }
 
-  beforeEach(function () {
+  beforeEach(function() {
     p = pFactory()
   })
 
-  afterEach(function () {
+  afterEach(function() {
     p.removeAllListeners('data')
     p.removeAllListeners('warning')
     p.removeAllListeners('error')
   })
 
-  describe('comments', function () {
-    it('should do nothing with most comments', function (done) {
-      p.once('data', function (d) {
+  describe('comments', function() {
+    it('should do nothing with most comments', function(done) {
+      p.once('data', function(d) {
         throw new Error('should not have emitted: ' + d)
       })
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         throw new Error('should not have warned: ' + w.message)
       })
-      p.once('error', function (e) {
+      p.once('error', function(e) {
         throw new Error('should not have errored: ' + e.message)
       })
 
@@ -55,9 +55,9 @@ describe('gerber parser with gerber files', function () {
       setTimeout(done, 1)
     })
 
-    describe('format hints', function () {
-      describe('kicad', function () {
-        it('should set format and suppresion if included', function () {
+    describe('format hints', function() {
+      describe('kicad', function() {
+        it('should set format and suppresion if included', function() {
           p.write(
             ';FORMAT={3:3/ absolute / metric / suppress trailing zeros}\n'
           )
@@ -84,12 +84,12 @@ describe('gerber parser with gerber files', function () {
           expect(p.format.places).to.eql([3, 3])
         })
 
-        it('should set backupUnits and backupNota', function (done) {
+        it('should set backupUnits and backupNota', function(done) {
           var expected = [
             {type: 'set', line: 1, prop: 'backupNota', value: 'A'},
             {type: 'set', line: 1, prop: 'backupUnits', value: 'mm'},
             {type: 'set', line: 2, prop: 'backupNota', value: 'I'},
-            {type: 'set', line: 2, prop: 'backupUnits', value: 'in'}
+            {type: 'set', line: 2, prop: 'backupUnits', value: 'in'},
           ]
 
           expectResults(expected, done)
@@ -103,15 +103,15 @@ describe('gerber parser with gerber files', function () {
         })
       })
 
-      describe('altium', function () {
-        it('should set format', function () {
+      describe('altium', function() {
+        it('should set format', function() {
           p.write(';FILE_FORMAT=4:4\n')
           p.end()
           expect(p.format.places).to.eql([4, 4])
         })
       })
 
-      it('should not overrite user set format with format hints', function () {
+      it('should not overrite user set format with format hints', function() {
         p.format.places = [2, 3]
         p.format.zero = 'T'
 
@@ -122,7 +122,7 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  it('should call done with M00 and M30', function (done) {
+  it('should call done with M00 and M30', function(done) {
     var expected = [{type: 'done', line: 1}, {type: 'done', line: 2}]
 
     expectResults(expected, done)
@@ -131,10 +131,10 @@ describe('gerber parser with gerber files', function () {
     p.end()
   })
 
-  it('should set notation with G90 and G91', function (done) {
+  it('should set notation with G90 and G91', function(done) {
     var expected = [
       {type: 'set', line: 1, prop: 'nota', value: 'A'},
-      {type: 'set', line: 2, prop: 'nota', value: 'I'}
+      {type: 'set', line: 2, prop: 'nota', value: 'I'},
     ]
 
     expectResults(expected, done)
@@ -143,13 +143,13 @@ describe('gerber parser with gerber files', function () {
     p.end()
   })
 
-  describe('parsing unit set', function () {
-    it('should set units and suppression with INCH / METRIC', function (done) {
+  describe('parsing unit set', function() {
+    it('should set units and suppression with INCH / METRIC', function(done) {
       var expected = [
         {type: 'set', line: 1, prop: 'units', value: 'in'},
         {type: 'set', line: 2, prop: 'units', value: 'mm'},
         {type: 'set', line: 3, prop: 'units', value: 'in'},
-        {type: 'set', line: 4, prop: 'units', value: 'mm'}
+        {type: 'set', line: 4, prop: 'units', value: 'mm'},
       ]
 
       expectResults(expected, done)
@@ -160,10 +160,10 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should set units with M71 and M72', function (done) {
+    it('should set units with M71 and M72', function(done) {
       var expected = [
         {type: 'set', line: 1, prop: 'units', value: 'in'},
-        {type: 'set', line: 2, prop: 'units', value: 'mm'}
+        {type: 'set', line: 2, prop: 'units', value: 'mm'},
       ]
 
       expectResults(expected, done)
@@ -172,7 +172,7 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should set places format when the units are set', function () {
+    it('should set places format when the units are set', function() {
       p.write('M71\n')
       p.end()
       expect(p.format.places).to.eql([3, 3])
@@ -193,7 +193,7 @@ describe('gerber parser with gerber files', function () {
       expect(p.format.places).to.eql([2, 4])
     })
 
-    it('should not overwrite places format', function () {
+    it('should not overwrite places format', function() {
       p.format.places = [3, 4]
 
       p.write('M71\n')
@@ -207,8 +207,8 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('setting zero suppression', function () {
-    it('should set zero suppression if included with units', function () {
+  describe('setting zero suppression', function() {
+    it('should set zero suppression if included with units', function() {
       p.write('INCH,TZ\n')
       p.end()
       expect(p.format.zero).to.equal('L')
@@ -219,7 +219,7 @@ describe('gerber parser with gerber files', function () {
       expect(p.format.zero).to.equal('T')
     })
 
-    it('should not overwrite suppression', function () {
+    it('should not overwrite suppression', function() {
       p.format.zero = 'L'
       p.write('METRIC,LZ\n')
       p.write('INCH,LZ\n')
@@ -232,15 +232,15 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('parsing tool definitions', function () {
-    it('should send a tool command', function (done) {
+  describe('parsing tool definitions', function() {
+    it('should send a tool command', function(done) {
       var expectedTools = [
         {shape: 'circle', params: [0.015], hole: []},
-        {shape: 'circle', params: [0.142], hole: []}
+        {shape: 'circle', params: [0.142], hole: []},
       ]
       var expected = [
         {type: 'tool', line: 1, code: '1', tool: expectedTools[0]},
-        {type: 'tool', line: 2, code: '13', tool: expectedTools[1]}
+        {type: 'tool', line: 2, code: '13', tool: expectedTools[1]},
       ]
 
       expectResults(expected, done)
@@ -249,16 +249,16 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should ignore feedrate and spindle speed', function (done) {
+    it('should ignore feedrate and spindle speed', function(done) {
       var expectedTools = [
         {shape: 'circle', params: [0.01], hole: []},
         {shape: 'circle', params: [0.02], hole: []},
-        {shape: 'circle', params: [0.03], hole: []}
+        {shape: 'circle', params: [0.03], hole: []},
       ]
       var expected = [
         {type: 'tool', line: 1, code: '1', tool: expectedTools[0]},
         {type: 'tool', line: 2, code: '2', tool: expectedTools[1]},
-        {type: 'tool', line: 3, code: '3', tool: expectedTools[2]}
+        {type: 'tool', line: 3, code: '3', tool: expectedTools[2]},
       ]
 
       expectResults(expected, done)
@@ -268,10 +268,10 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should ignore leading zeros in tool name', function (done) {
+    it('should ignore leading zeros in tool name', function(done) {
       var expectedTools = [{shape: 'circle', params: [0.015], hole: []}]
       var expected = [
-        {type: 'tool', line: 1, code: '23', tool: expectedTools[0]}
+        {type: 'tool', line: 1, code: '23', tool: expectedTools[0]},
       ]
 
       expectResults(expected, done)
@@ -280,13 +280,13 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  it('should set the tool with a tool number', function (done) {
+  it('should set the tool with a tool number', function(done) {
     var expected = [
       {type: 'set', line: 1, prop: 'tool', value: '1'},
       {type: 'set', line: 2, prop: 'tool', value: '14'},
       {type: 'set', line: 3, prop: 'tool', value: '5'},
       {type: 'set', line: 4, prop: 'tool', value: '0'},
-      {type: 'set', line: 5, prop: 'tool', value: '0'}
+      {type: 'set', line: 5, prop: 'tool', value: '0'},
     ]
 
     expectResults(expected, done)
@@ -298,14 +298,14 @@ describe('gerber parser with gerber files', function () {
     p.end()
   })
 
-  describe('parsing drill commands', function () {
-    it('should work with trailing suppression', function (done) {
+  describe('parsing drill commands', function() {
+    it('should work with trailing suppression', function(done) {
       p.format.places = [2, 4]
       p.format.zero = 'T'
 
       var expected = [
         {type: 'op', line: 1, op: 'flash', coord: {x: 0.16, y: 1.58}},
-        {type: 'op', line: 2, op: 'flash', coord: {x: -1.795, y: 1.08}}
+        {type: 'op', line: 2, op: 'flash', coord: {x: -1.795, y: 1.08}},
       ]
 
       expectResults(expected, done)
@@ -313,13 +313,13 @@ describe('gerber parser with gerber files', function () {
       p.write('X-01795Y0108\n')
     })
 
-    it('should work with leading zeros suppressed', function (done) {
+    it('should work with leading zeros suppressed', function(done) {
       p.format.places = [2, 4]
       p.format.zero = 'L'
 
       var expected = [
         {type: 'op', line: 1, op: 'flash', coord: {x: 0.005, y: 1.55}},
-        {type: 'op', line: 2, op: 'flash', coord: {x: 1.685, y: -0.33}}
+        {type: 'op', line: 2, op: 'flash', coord: {x: 1.685, y: -0.33}},
       ]
 
       expectResults(expected, done)
@@ -327,12 +327,12 @@ describe('gerber parser with gerber files', function () {
       p.write('X16850Y-3300\n')
     })
 
-    it('should parse with the places format', function (done) {
+    it('should parse with the places format', function(done) {
       var expected = [
         {type: 'op', line: 1, op: 'flash', coord: {x: 0.755, y: 1.4}},
         {type: 'op', line: 2, op: 'flash', coord: {x: 7.55, y: 0.014}},
         {type: 'op', line: 3, op: 'flash', coord: {x: 8, y: 1.24}},
-        {type: 'op', line: 4, op: 'flash', coord: {x: 80, y: 12.4}}
+        {type: 'op', line: 4, op: 'flash', coord: {x: 80, y: 12.4}},
       ]
 
       expectResults(expected, done)
@@ -352,19 +352,19 @@ describe('gerber parser with gerber files', function () {
       p.write('X08Y0124\n')
     })
 
-    it('should parse decimal coordinates', function (done) {
+    it('should parse decimal coordinates', function(done) {
       p.format.zero = 'L'
       p.format.places = [2, 4]
 
       var expected = [
-        {type: 'op', line: 1, op: 'flash', coord: {x: 0.755, y: 1.4}}
+        {type: 'op', line: 1, op: 'flash', coord: {x: 0.755, y: 1.4}},
       ]
 
       expectResults(expected, done)
       p.write('X0.7550Y1.4000\n')
     })
 
-    it('should parse tool change at beginning / end of line', function (done) {
+    it('should parse tool change at beginning / end of line', function(done) {
       p.format.zero = 'T'
       p.format.places = [2, 4]
 
@@ -372,7 +372,7 @@ describe('gerber parser with gerber files', function () {
         {type: 'set', line: 1, prop: 'tool', value: '1'},
         {type: 'op', line: 1, op: 'flash', coord: {x: 1, y: 1}},
         {type: 'set', line: 2, prop: 'tool', value: '1'},
-        {type: 'op', line: 2, op: 'flash', coord: {x: 1, y: 1}}
+        {type: 'op', line: 2, op: 'flash', coord: {x: 1, y: 1}},
       ]
 
       expectResults(expected, done)
@@ -381,9 +381,9 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should warn / assume trailing if missing', function (done) {
+    it('should warn / assume trailing if missing', function(done) {
       p.format.places = [2, 4]
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/assuming trailing/)
         expect(p.format.zero).to.equal('T')
         done()
@@ -393,9 +393,9 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should warn / assume trailing if undetectable after 1000 coordinates', function (done) {
+    it('should warn / assume trailing if undetectable after 1000 coordinates', function(done) {
       p.format.places = [2, 4]
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/assuming trailing/)
         expect(p.format.zero).to.equal('T')
         done()
@@ -405,9 +405,9 @@ describe('gerber parser with gerber files', function () {
       }
     })
 
-    it('should warn / assume [2, 4] places if missing', function (done) {
+    it('should warn / assume [2, 4] places if missing', function(done) {
       p.format.zero = 'L'
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/assuming \[2, 4\]/)
         expect(p.format.places).to.eql([2, 4])
         done()
@@ -417,9 +417,9 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should warn / detect leading if possible', function (done) {
+    it('should warn / detect leading if possible', function(done) {
       p.format.places = [2, 4]
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/detected leading/)
         expect(p.format.zero).to.equal('L')
         done()
@@ -428,8 +428,8 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('parsing slot commands', function () {
-    it('should parse the slot commands', function (done) {
+  describe('parsing slot commands', function() {
+    it('should parse the slot commands', function(done) {
       p.format.places = [2, 4]
       p.format.zero = 'T'
 
@@ -443,7 +443,7 @@ describe('gerber parser with gerber files', function () {
         {type: 'op', line: 3, op: 'int', coord: {y: -0.1}},
         {type: 'op', line: 4, op: 'move', coord: {y: 3.09}},
         {type: 'set', line: 4, prop: 'mode', value: 'i'},
-        {type: 'op', line: 4, op: 'int', coord: {y: 3.29}}
+        {type: 'op', line: 4, op: 'int', coord: {y: 3.29}},
       ]
 
       expectResults(expected, done)
@@ -454,16 +454,16 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('drill file routing', function () {
-    beforeEach(function () {
+  describe('drill file routing', function() {
+    beforeEach(function() {
       p.format.places = [1, 2]
       p.format.zero = 'T'
     })
 
-    it('should handle turning route mode on', function (done) {
+    it('should handle turning route mode on', function(done) {
       var expected = [
         {type: 'op', line: 1, op: 'move', coord: {x: 0.12, y: 3.45}},
-        {type: 'op', line: 2, op: 'move', coord: {x: 0.67, y: 8.9}}
+        {type: 'op', line: 2, op: 'move', coord: {x: 0.67, y: 8.9}},
       ]
 
       expectResults(expected, done)
@@ -472,13 +472,13 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    it('should handle linear routing', function (done) {
+    it('should handle linear routing', function(done) {
       var expected = [
         {type: 'op', line: 1, op: 'move', coord: {x: 1, y: 1}},
         {type: 'set', line: 2, prop: 'mode', value: 'i'},
         {type: 'op', line: 2, op: 'int', coord: {x: 2, y: 2}},
         {type: 'set', line: 3, prop: 'mode', value: 'i'},
-        {type: 'op', line: 3, op: 'int', coord: {x: 3, y: 3}}
+        {type: 'op', line: 3, op: 'int', coord: {x: 3, y: 3}},
       ]
 
       expectResults(expected, done)
@@ -488,18 +488,18 @@ describe('gerber parser with gerber files', function () {
       p.end()
     })
 
-    describe('arc routing', function () {
-      it('should handle cw arc routing with offsets', function (done) {
+    describe('arc routing', function() {
+      it('should handle cw arc routing with offsets', function(done) {
         var coords = [
           {x: 2, y: 2, i: 0.5, j: 0.5},
-          {x: 3, y: 3, i: 0.5, j: 0.5}
+          {x: 3, y: 3, i: 0.5, j: 0.5},
         ]
         var expected = [
           {type: 'op', line: 1, op: 'move', coord: {x: 1, y: 1}},
           {type: 'set', line: 2, prop: 'mode', value: 'cw'},
           {type: 'op', line: 2, op: 'int', coord: coords[0]},
           {type: 'set', line: 3, prop: 'mode', value: 'cw'},
-          {type: 'op', line: 3, op: 'int', coord: coords[1]}
+          {type: 'op', line: 3, op: 'int', coord: coords[1]},
         ]
 
         expectResults(expected, done)
@@ -509,17 +509,17 @@ describe('gerber parser with gerber files', function () {
         p.end()
       })
 
-      it('should handle ccw arc routing with offsets', function (done) {
+      it('should handle ccw arc routing with offsets', function(done) {
         var coords = [
           {x: 2, y: 2, i: 0.5, j: 0.5},
-          {x: 3, y: 3, i: 0.5, j: 0.5}
+          {x: 3, y: 3, i: 0.5, j: 0.5},
         ]
         var expected = [
           {type: 'op', line: 1, op: 'move', coord: {x: 1, y: 1}},
           {type: 'set', line: 2, prop: 'mode', value: 'ccw'},
           {type: 'op', line: 2, op: 'int', coord: coords[0]},
           {type: 'set', line: 3, prop: 'mode', value: 'ccw'},
-          {type: 'op', line: 3, op: 'int', coord: coords[1]}
+          {type: 'op', line: 3, op: 'int', coord: coords[1]},
         ]
 
         expectResults(expected, done)
@@ -529,14 +529,14 @@ describe('gerber parser with gerber files', function () {
         p.end()
       })
 
-      it('should handle cw arc routing with radius', function (done) {
+      it('should handle cw arc routing with radius', function(done) {
         var coords = [{x: 2, y: 2, a: 1}, {x: 3, y: 3, a: 1}]
         var expected = [
           {type: 'op', line: 1, op: 'move', coord: {x: 1, y: 1}},
           {type: 'set', line: 2, prop: 'mode', value: 'cw'},
           {type: 'op', line: 2, op: 'int', coord: coords[0]},
           {type: 'set', line: 3, prop: 'mode', value: 'cw'},
-          {type: 'op', line: 3, op: 'int', coord: coords[1]}
+          {type: 'op', line: 3, op: 'int', coord: coords[1]},
         ]
 
         expectResults(expected, done)
@@ -546,14 +546,14 @@ describe('gerber parser with gerber files', function () {
         p.end()
       })
 
-      it('should handle ccw arc routing with radius', function (done) {
+      it('should handle ccw arc routing with radius', function(done) {
         var coords = [{x: 2, y: 2, a: 1}, {x: 3, y: 3, a: 1}]
         var expected = [
           {type: 'op', line: 1, op: 'move', coord: {x: 1, y: 1}},
           {type: 'set', line: 2, prop: 'mode', value: 'ccw'},
           {type: 'op', line: 2, op: 'int', coord: coords[0]},
           {type: 'set', line: 3, prop: 'mode', value: 'ccw'},
-          {type: 'op', line: 3, op: 'int', coord: coords[1]}
+          {type: 'op', line: 3, op: 'int', coord: coords[1]},
         ]
 
         expectResults(expected, done)

--- a/packages/gerber-parser/test/gerber-parser_gerber_test.js
+++ b/packages/gerber-parser/test/gerber-parser_gerber_test.js
@@ -7,13 +7,13 @@ var partial = require('lodash/partial')
 
 var parser = require('../lib')
 
-describe('gerber parser with gerber files', function () {
+describe('gerber parser with gerber files', function() {
   var p
   var pFactory = partial(parser, {filetype: 'gerber'})
 
   // convenience function to expect an array of results
-  var expectResults = function (expected, done) {
-    var handleData = function (res) {
+  var expectResults = function(expected, done) {
+    var handleData = function(res) {
       expect(res).to.eql(expected.shift())
       if (!expected.length) {
         return done()
@@ -23,26 +23,26 @@ describe('gerber parser with gerber files', function () {
     p.on('data', handleData)
   }
 
-  beforeEach(function () {
+  beforeEach(function() {
     p = pFactory()
   })
 
-  afterEach(function () {
+  afterEach(function() {
     p.removeAllListeners('data')
     p.removeAllListeners('warning')
     p.removeAllListeners('error')
   })
 
-  it('should do nothing with comments', function (done) {
-    p.once('data', function () {
+  it('should do nothing with comments', function(done) {
+    p.once('data', function() {
       p.removeAllListeners('warning').removeAllListeners('error')
       throw new Error('should not have emitted from comments')
     })
-    p.once('warning', function () {
+    p.once('warning', function() {
       p.removeAllListeners('data').removeAllListeners('error')
       throw new Error('should not have warned from comments')
     })
-    p.once('error', function () {
+    p.once('error', function() {
       p.removeAllListeners('warning').removeAllListeners('data')
       throw new Error('should not have errored from comments')
     })
@@ -56,16 +56,16 @@ describe('gerber parser with gerber files', function () {
     setTimeout(done, 1)
   })
 
-  it('should do nothing with "empty" blocks', function (done) {
-    p.once('data', function () {
+  it('should do nothing with "empty" blocks', function(done) {
+    p.once('data', function() {
       p.removeAllListeners('warning').removeAllListeners('error')
       throw new Error('should not have emitted from empty block')
     })
-    p.once('warning', function () {
+    p.once('warning', function() {
       p.removeAllListeners('data').removeAllListeners('error')
       throw new Error('should not have warned from empty block')
     })
-    p.once('error', function () {
+    p.once('error', function() {
       p.removeAllListeners('warning').removeAllListeners('data')
       throw new Error('should not have errored from empty block')
     })
@@ -77,8 +77,8 @@ describe('gerber parser with gerber files', function () {
     setTimeout(done, 1)
   })
 
-  it('should warn if a block is unhandled', function (done) {
-    p.once('warning', function (w) {
+  it('should warn if a block is unhandled', function(done) {
+    p.once('warning', function(w) {
       expect(w.line).to.equal(0)
       expect(w.message).to.match(/not recognized/)
       done()
@@ -87,16 +87,16 @@ describe('gerber parser with gerber files', function () {
     p.write('foobarbaz*\n')
   })
 
-  it('should handle split blocks', function (done) {
-    p.once('data', function () {
+  it('should handle split blocks', function(done) {
+    p.once('data', function() {
       p.removeAllListeners('warning').removeAllListeners('error')
       throw new Error('should not have emitted from split comment')
     })
-    p.once('warning', function () {
+    p.once('warning', function() {
       p.removeAllListeners('data').removeAllListeners('error')
       throw new Error('should not have warned from split comment')
     })
-    p.once('error', function () {
+    p.once('error', function() {
       p.removeAllListeners('warning').removeAllListeners('data')
       throw new Error('should not have errored from split comment')
     })
@@ -106,32 +106,32 @@ describe('gerber parser with gerber files', function () {
     setTimeout(done, 1)
   })
 
-  it('should end the file with a M02', function (done) {
+  it('should end the file with a M02', function(done) {
     var expected = [{type: 'done', line: 0}]
 
     expectResults(expected, done)
     p.write('M02*\n')
   })
 
-  describe('general set commands (G-codes)', function () {
-    it('should set region mode on/off with G36/7', function (done) {
+  describe('general set commands (G-codes)', function() {
+    it('should set region mode on/off with G36/7', function(done) {
       var expected = [
         {type: 'set', prop: 'region', value: true, line: 0},
-        {type: 'set', prop: 'region', value: false, line: 1}
+        {type: 'set', prop: 'region', value: false, line: 1},
       ]
 
       expectResults(expected, done)
       p.write('G36*\nG37*\n')
     })
 
-    it('should set interpolation mode with G01/2/3', function (done) {
+    it('should set interpolation mode with G01/2/3', function(done) {
       var expected = [
         {type: 'set', prop: 'mode', value: 'i', line: 0},
         {type: 'set', prop: 'mode', value: 'cw', line: 1},
         {type: 'set', prop: 'mode', value: 'ccw', line: 2},
         {type: 'set', prop: 'mode', value: 'i', line: 3},
         {type: 'set', prop: 'mode', value: 'cw', line: 4},
-        {type: 'set', prop: 'mode', value: 'ccw', line: 5}
+        {type: 'set', prop: 'mode', value: 'ccw', line: 5},
       ]
 
       expectResults(expected, done)
@@ -139,10 +139,10 @@ describe('gerber parser with gerber files', function () {
       p.write('G1*\nG2*\nG3*\n')
     })
 
-    it('should set the arc mode with G74/5', function (done) {
+    it('should set the arc mode with G74/5', function(done) {
       var expected = [
         {type: 'set', prop: 'arc', value: 's', line: 0},
-        {type: 'set', prop: 'arc', value: 'm', line: 1}
+        {type: 'set', prop: 'arc', value: 'm', line: 1},
       ]
 
       expectResults(expected, done)
@@ -150,11 +150,11 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('unit set commands (MO parameter)', function () {
-    it('should set units with %MOIN*% and %MOMM*%', function (done) {
+  describe('unit set commands (MO parameter)', function() {
+    it('should set units with %MOIN*% and %MOMM*%', function(done) {
       var expected = [
         {type: 'set', prop: 'units', value: 'in', line: 0},
-        {type: 'set', prop: 'units', value: 'mm', line: 1}
+        {type: 'set', prop: 'units', value: 'mm', line: 1},
       ]
 
       expectResults(expected, done)
@@ -162,10 +162,10 @@ describe('gerber parser with gerber files', function () {
       p.write('%MOMM*%\n')
     })
 
-    it('should set backup units with G70/1', function (done) {
+    it('should set backup units with G70/1', function(done) {
       var expected = [
         {type: 'set', prop: 'backupUnits', value: 'in', line: 0},
-        {type: 'set', prop: 'backupUnits', value: 'mm', line: 1}
+        {type: 'set', prop: 'backupUnits', value: 'mm', line: 1},
       ]
 
       expectResults(expected, done)
@@ -173,8 +173,8 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('format block', function () {
-    it('should parse zero suppression', function () {
+  describe('format block', function() {
+    it('should parse zero suppression', function() {
       var format = '%FSLAX34Y34*%'
       p.write(format)
       expect(p.format.zero).to.equal('L')
@@ -185,8 +185,8 @@ describe('gerber parser with gerber files', function () {
       expect(p.format.zero).to.equal('T')
     })
 
-    it('should warn trailing suppression is deprected', function (done) {
-      p.once('warning', function (w) {
+    it('should warn trailing suppression is deprected', function(done) {
+      p.once('warning', function(w) {
         expect(w.line).to.equal(0)
         expect(w.message).to.match(/trailing zero suppression/)
         done()
@@ -195,7 +195,7 @@ describe('gerber parser with gerber files', function () {
       p.write('%FSTAX34Y34*%\n')
     })
 
-    it('should parse places format', function () {
+    it('should parse places format', function() {
       var format = '%FSLAX34Y34*%'
       p.write(format)
       expect(p.format.places).to.eql([3, 4])
@@ -206,7 +206,7 @@ describe('gerber parser with gerber files', function () {
       expect(p.format.places).to.eql([7, 7])
     })
 
-    it('should not override user-set places or suppression', function () {
+    it('should not override user-set places or suppression', function() {
       var format = '%FSLAX34Y34*%'
       p.format.zero = 'T'
       p.format.places = [7, 7]
@@ -215,7 +215,7 @@ describe('gerber parser with gerber files', function () {
       expect(p.format.places).to.eql([7, 7])
     })
 
-    it('should set notation and epsilon', function (done) {
+    it('should set notation and epsilon', function(done) {
       var format1 = '%FSLAX34Y34*%\n'
       var format2 = '%FSLIX77Y77*%\n'
       // ensure it parses if suppression is missing
@@ -226,7 +226,7 @@ describe('gerber parser with gerber files', function () {
         {type: 'set', line: 1, prop: 'nota', value: 'I'},
         {type: 'set', line: 1, prop: 'epsilon', value: 1.5 * Math.pow(10, -7)},
         {type: 'set', line: 2, prop: 'nota', value: 'A'},
-        {type: 'set', line: 2, prop: 'epsilon', value: 1.5 * Math.pow(10, -6)}
+        {type: 'set', line: 2, prop: 'epsilon', value: 1.5 * Math.pow(10, -6)},
       ]
 
       expectResults(expected, done)
@@ -238,9 +238,9 @@ describe('gerber parser with gerber files', function () {
       p.write(format3)
     })
 
-    it('should warn and set leading if suppression missing', function (done) {
+    it('should warn and set leading if suppression missing', function(done) {
       var format = '%FSAX34Y34*%\n'
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.line).to.equal(0)
         expect(w.message).to.match(/suppression missing/)
         expect(p.format.zero).to.equal('L')
@@ -250,10 +250,10 @@ describe('gerber parser with gerber files', function () {
       p.write(format)
     })
 
-    it('should be able to set backup notation with G90/1', function (done) {
+    it('should be able to set backup notation with G90/1', function(done) {
       var expected = [
         {type: 'set', line: 0, prop: 'backupNota', value: 'A'},
-        {type: 'set', line: 1, prop: 'backupNota', value: 'I'}
+        {type: 'set', line: 1, prop: 'backupNota', value: 'I'},
       ]
 
       expectResults(expected, done)
@@ -261,10 +261,10 @@ describe('gerber parser with gerber files', function () {
       p.write('G91*\n')
     })
 
-    it('should warn but still set format if there are extra characters', function (done) {
+    it('should warn but still set format if there are extra characters', function(done) {
       var format = '%FSLAN2X34Y34*%\n'
 
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.line).to.equal(0)
         expect(w.message).to.match(/unknown characters/)
         expect(p.format.zero).to.equal('L')
@@ -276,37 +276,37 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('new level commands (SR/LP parameters)', function () {
-    it('should parse a new level polarity', function (done) {
+  describe('new level commands (SR/LP parameters)', function() {
+    it('should parse a new level polarity', function(done) {
       var expected = [
         {type: 'level', line: 0, level: 'polarity', value: 'D'},
-        {type: 'level', line: 1, level: 'polarity', value: 'C'}
+        {type: 'level', line: 1, level: 'polarity', value: 'C'},
       ]
 
       expectResults(expected, done)
       p.write('%LPD*%\n%LPC*%')
     })
 
-    it('should parse a new step-repeat level', function (done) {
+    it('should parse a new step-repeat level', function(done) {
       var expected = [
         {
           type: 'level',
           line: 0,
           level: 'stepRep',
-          value: {x: 1, y: 1, i: 0, j: 0}
+          value: {x: 1, y: 1, i: 0, j: 0},
         },
         {
           type: 'level',
           line: 1,
           level: 'stepRep',
-          value: {x: 2, y: 3, i: 2, j: 3}
+          value: {x: 2, y: 3, i: 2, j: 3},
         },
         {
           type: 'level',
           line: 2,
           level: 'stepRep',
-          value: {x: 1, y: 1, i: 0, j: 0}
-        }
+          value: {x: 1, y: 1, i: 0, j: 0},
+        },
       ]
 
       expectResults(expected, done)
@@ -317,17 +317,17 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('tool changes and definitions', function () {
-    beforeEach(function () {
+  describe('tool changes and definitions', function() {
+    beforeEach(function() {
       p.format.zero = 'L'
       p.format.places = [2, 2]
     })
 
-    it('should parse a tool change block', function (done) {
+    it('should parse a tool change block', function(done) {
       var expected = [
         {type: 'set', line: 0, prop: 'tool', value: '10'},
         {type: 'set', line: 1, prop: 'tool', value: '11'},
-        {type: 'set', line: 2, prop: 'tool', value: '12'}
+        {type: 'set', line: 2, prop: 'tool', value: '12'},
       ]
 
       expectResults(expected, done)
@@ -336,16 +336,16 @@ describe('gerber parser with gerber files', function () {
       p.write('D00012*\n')
     })
 
-    it('should handle standard circles', function (done) {
+    it('should handle standard circles', function(done) {
       var expectedTools = [
         {shape: 'circle', params: [1], hole: []},
         {shape: 'circle', params: [1], hole: [0.1]},
-        {shape: 'circle', params: [1], hole: [0.2, 0.3]}
+        {shape: 'circle', params: [1], hole: [0.2, 0.3]},
       ]
       var expected = [
         {type: 'tool', line: 0, code: '10', tool: expectedTools[0]},
         {type: 'tool', line: 1, code: '11', tool: expectedTools[1]},
-        {type: 'tool', line: 2, code: '12', tool: expectedTools[2]}
+        {type: 'tool', line: 2, code: '12', tool: expectedTools[2]},
       ]
 
       expectResults(expected, done)
@@ -354,16 +354,16 @@ describe('gerber parser with gerber files', function () {
       p.write('%ADD12C,1X0.2X0.3*%\n')
     })
 
-    it('should handle standard rectangles/obrounds', function (done) {
+    it('should handle standard rectangles/obrounds', function(done) {
       var expectedTools = [
         {shape: 'rect', params: [1, 2], hole: []},
         {shape: 'obround', params: [3, 4], hole: [0.1]},
-        {shape: 'rect', params: [5, 6], hole: [0.2, 0.3]}
+        {shape: 'rect', params: [5, 6], hole: [0.2, 0.3]},
       ]
       var expected = [
         {type: 'tool', line: 0, code: '10', tool: expectedTools[0]},
         {type: 'tool', line: 1, code: '11', tool: expectedTools[1]},
-        {type: 'tool', line: 2, code: '12', tool: expectedTools[2]}
+        {type: 'tool', line: 2, code: '12', tool: expectedTools[2]},
       ]
 
       expectResults(expected, done)
@@ -372,18 +372,18 @@ describe('gerber parser with gerber files', function () {
       p.write('%ADD12R,5X6X0.2X0.3*%\n')
     })
 
-    it('should handle standard polygons', function (done) {
+    it('should handle standard polygons', function(done) {
       var expectedTools = [
         {shape: 'poly', params: [1, 5, 0], hole: []},
         {shape: 'poly', params: [2, 6, 45], hole: []},
         {shape: 'poly', params: [3, 7, 0], hole: [0.1]},
-        {shape: 'poly', params: [4, 8, 0], hole: [0.2, 0.3]}
+        {shape: 'poly', params: [4, 8, 0], hole: [0.2, 0.3]},
       ]
       var expected = [
         {type: 'tool', line: 0, code: '10', tool: expectedTools[0]},
         {type: 'tool', line: 1, code: '11', tool: expectedTools[1]},
         {type: 'tool', line: 2, code: '12', tool: expectedTools[2]},
-        {type: 'tool', line: 3, code: '13', tool: expectedTools[3]}
+        {type: 'tool', line: 3, code: '13', tool: expectedTools[3]},
       ]
 
       expectResults(expected, done)
@@ -393,14 +393,14 @@ describe('gerber parser with gerber files', function () {
       p.write('%ADD13P,4X8X0X0.2X0.3*%\n')
     })
 
-    it('should handle aperture macro tools', function (done) {
+    it('should handle aperture macro tools', function(done) {
       var expectedTools = [
         {shape: 'CIRC', params: [1, 0.5], hole: []},
-        {shape: 'RECT', params: [], hole: []}
+        {shape: 'RECT', params: [], hole: []},
       ]
       var expected = [
         {type: 'tool', line: 0, code: '10', tool: expectedTools[0]},
-        {type: 'tool', line: 1, code: '11', tool: expectedTools[1]}
+        {type: 'tool', line: 1, code: '11', tool: expectedTools[1]},
       ]
 
       expectResults(expected, done)
@@ -408,10 +408,10 @@ describe('gerber parser with gerber files', function () {
       p.write('%ADD11RECT*%\n')
     })
 
-    it('should handle tool defs with leading zeros', function (done) {
+    it('should handle tool defs with leading zeros', function(done) {
       var expectedTools = [{shape: 'circle', params: [1], hole: []}]
       var expected = [
-        {type: 'tool', line: 0, code: '10', tool: expectedTools[0]}
+        {type: 'tool', line: 0, code: '10', tool: expectedTools[0]},
       ]
 
       expectResults(expected, done)
@@ -419,14 +419,14 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('aperture macros', function () {
-    it('should parse the name of the macro properly', function (done) {
+  describe('aperture macros', function() {
+    it('should parse the name of the macro properly', function(done) {
       var expected = [
         {type: 'macro', line: 0, name: 'NAME1', blocks: []},
         {type: 'macro', line: 1, name: 'CRAZY8', blocks: []},
         {type: 'macro', line: 2, name: 'NAME-1', blocks: []},
         {type: 'macro', line: 3, name: 'Name1.0', blocks: []},
-        {type: 'macro', line: 4, name: '$Name1', blocks: []}
+        {type: 'macro', line: 4, name: '$Name1', blocks: []},
       ]
 
       expectResults(expected, done)
@@ -437,8 +437,8 @@ describe('gerber parser with gerber files', function () {
       p.write('%AM$Name1*%\n')
     })
 
-    it('should warn that hyphens in macro names are invalid', function (done) {
-      p.once('warning', function (w) {
+    it('should warn that hyphens in macro names are invalid', function(done) {
+      p.once('warning', function(w) {
         expect(w.line).to.equal(0)
         expect(w.message).to.match(/hyphen/)
         done()
@@ -447,13 +447,13 @@ describe('gerber parser with gerber files', function () {
       p.write('%AMNAME-1*%\n')
     })
 
-    describe('primitive blocks', function () {
+    describe('primitive blocks', function() {
       var exp = 1
 
-      it('should parse comments', function (done) {
+      it('should parse comments', function(done) {
         var expectedBlocks = [{type: 'comment'}]
         var expected = [
-          {type: 'macro', line: 1, name: 'NAME1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'NAME1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -461,13 +461,13 @@ describe('gerber parser with gerber files', function () {
         p.write('0 a comment*%\n')
       })
 
-      it('should parse circle primitives', function (done) {
+      it('should parse circle primitives', function(done) {
         var expectedBlocks = [
           {type: 'circle', exp: exp, dia: 5, cx: 1, cy: 2, rot: 0},
-          {type: 'circle', exp: exp, dia: 3, cx: 4, cy: 5, rot: 20}
+          {type: 'circle', exp: exp, dia: 3, cx: 4, cy: 5, rot: 20},
         ]
         var expected = [
-          {type: 'macro', line: 2, name: 'CIRC1', blocks: expectedBlocks}
+          {type: 'macro', line: 2, name: 'CIRC1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -476,7 +476,7 @@ describe('gerber parser with gerber files', function () {
         p.write('1,1,3,4,5,20*%\n')
       })
 
-      it('should parse vector primitives', function (done) {
+      it('should parse vector primitives', function(done) {
         var expectedBlocks = [
           {
             type: 'vect',
@@ -486,7 +486,7 @@ describe('gerber parser with gerber files', function () {
             y1: 4,
             x2: 5,
             y2: 6,
-            rot: 7
+            rot: 7,
           },
           {
             type: 'vect',
@@ -496,11 +496,11 @@ describe('gerber parser with gerber files', function () {
             y1: 4,
             x2: 5,
             y2: 6,
-            rot: 7
-          }
+            rot: 7,
+          },
         ]
         var expected = [
-          {type: 'macro', line: 2, name: 'VECT1', blocks: expectedBlocks}
+          {type: 'macro', line: 2, name: 'VECT1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -509,8 +509,8 @@ describe('gerber parser with gerber files', function () {
         p.write('20,1,2,3,4,5,6,7*%\n')
       })
 
-      it('should warn that primitive code 2 is deprecated', function (done) {
-        p.once('warning', function (w) {
+      it('should warn that primitive code 2 is deprecated', function(done) {
+        p.once('warning', function(w) {
           expect(w.line).to.equal(1)
           expect(w.message).to.match(/vector.*deprecated/)
           done()
@@ -520,12 +520,12 @@ describe('gerber parser with gerber files', function () {
         p.write('2,1,2,3,4,5,6,7*%\n')
       })
 
-      it('should parse rectangle primitives', function (done) {
+      it('should parse rectangle primitives', function(done) {
         var expectedBlocks = [
-          {type: 'rect', exp: exp, width: 2, height: 3, cx: 4, cy: 5, rot: 6}
+          {type: 'rect', exp: exp, width: 2, height: 3, cx: 4, cy: 5, rot: 6},
         ]
         var expected = [
-          {type: 'macro', line: 1, name: 'RECT1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'RECT1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -533,12 +533,12 @@ describe('gerber parser with gerber files', function () {
         p.write('21,1,2,3,4,5,6*%\n')
       })
 
-      it('should parse a lower left rectangle primitive', function (done) {
+      it('should parse a lower left rectangle primitive', function(done) {
         var expectedBlocks = [
-          {type: 'rectLL', exp: exp, width: 2, height: 3, x: 4, y: 5, rot: 6}
+          {type: 'rectLL', exp: exp, width: 2, height: 3, x: 4, y: 5, rot: 6},
         ]
         var expected = [
-          {type: 'macro', line: 1, name: 'RECTLL1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'RECTLL1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -546,8 +546,8 @@ describe('gerber parser with gerber files', function () {
         p.write('22,1,2,3,4,5,6*%\n')
       })
 
-      it('should warn that primitive code 22 is deprecated', function (done) {
-        p.once('warning', function (w) {
+      it('should warn that primitive code 22 is deprecated', function(done) {
+        p.once('warning', function(w) {
           expect(w.line).to.equal(1)
           expect(w.message).to.match(/lower-left.*deprecated/)
           done()
@@ -557,12 +557,12 @@ describe('gerber parser with gerber files', function () {
         p.write('22,1,2,3,4,5,6*%\n')
       })
 
-      it('should parse an outline polygon primitive', function (done) {
+      it('should parse an outline polygon primitive', function(done) {
         var expectedBlocks = [
-          {type: 'outline', exp: exp, points: [3, 4, 5, 6, 7, 8], rot: 9}
+          {type: 'outline', exp: exp, points: [3, 4, 5, 6, 7, 8], rot: 9},
         ]
         var expected = [
-          {type: 'macro', line: 1, name: 'OUT1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'OUT1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -570,12 +570,12 @@ describe('gerber parser with gerber files', function () {
         p.write('4,1,2,3,4,5,6,7,8,9*%\n')
       })
 
-      it('should parse a regular polygon primitive', function (done) {
+      it('should parse a regular polygon primitive', function(done) {
         var expectedBlocks = [
-          {type: 'poly', exp: exp, vertices: 3, cx: 4, cy: 5, dia: 6, rot: 7}
+          {type: 'poly', exp: exp, vertices: 3, cx: 4, cy: 5, dia: 6, rot: 7},
         ]
         var expected = [
-          {type: 'macro', line: 1, name: 'POLY1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'POLY1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -583,7 +583,7 @@ describe('gerber parser with gerber files', function () {
         p.write('5,1,3,4,5,6,7*%\n')
       })
 
-      it('should parse a moire primitive', function (done) {
+      it('should parse a moire primitive', function(done) {
         var expectedBlocks = [
           {
             type: 'moire',
@@ -596,11 +596,11 @@ describe('gerber parser with gerber files', function () {
             maxRings: 6,
             crossThx: 7,
             crossLen: 8,
-            rot: 9
-          }
+            rot: 9,
+          },
         ]
         var expected = [
-          {type: 'macro', line: 1, name: 'MOIRE1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'MOIRE1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -608,7 +608,7 @@ describe('gerber parser with gerber files', function () {
         p.write('6,1,2,3,4,5,6,7,8,9*%\n')
       })
 
-      it('should parse a thermal primitive', function (done) {
+      it('should parse a thermal primitive', function(done) {
         var expectedBlocks = [
           {
             type: 'thermal',
@@ -618,11 +618,11 @@ describe('gerber parser with gerber files', function () {
             outerDia: 3,
             innerDia: 4,
             gap: 5,
-            rot: 6
-          }
+            rot: 6,
+          },
         ]
         var expected = [
-          {type: 'macro', line: 1, name: 'THERMAL1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'THERMAL1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -630,8 +630,8 @@ describe('gerber parser with gerber files', function () {
         p.write('7,1,2,3,4,5,6*%\n')
       })
 
-      it('should warn if the primitive is unrecognized', function (done) {
-        p.once('warning', function (w) {
+      it('should warn if the primitive is unrecognized', function(done) {
+        p.once('warning', function(w) {
           expect(w.line).to.equal(1)
           expect(w.message).to.match(/unrecognized primitive/)
           done()
@@ -641,12 +641,12 @@ describe('gerber parser with gerber files', function () {
         p.write('8,1,2,3,4,5,6,7*%\n')
       })
 
-      it('should parse primitives with negative parameters', function (done) {
+      it('should parse primitives with negative parameters', function(done) {
         var expectedBlocks = [
-          {type: 'circle', exp: exp, dia: 5, cx: -1, cy: -2.5, rot: 0}
+          {type: 'circle', exp: exp, dia: 5, cx: -1, cy: -2.5, rot: 0},
         ]
         var expected = [
-          {type: 'macro', line: 1, name: 'CIRC1', blocks: expectedBlocks}
+          {type: 'macro', line: 1, name: 'CIRC1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -654,12 +654,12 @@ describe('gerber parser with gerber files', function () {
         p.write('1,1,5,-1,-2.5*%\n')
       })
 
-      it('should ignore empty blocks', function (done) {
+      it('should ignore empty blocks', function(done) {
         var expectedBlocks = [
-          {type: 'circle', exp: exp, dia: 5, cx: 1, cy: 2, rot: 0}
+          {type: 'circle', exp: exp, dia: 5, cx: 1, cy: 2, rot: 0},
         ]
         var expected = [
-          {type: 'macro', line: 2, name: 'CIRC1', blocks: expectedBlocks}
+          {type: 'macro', line: 2, name: 'CIRC1', blocks: expectedBlocks},
         ]
 
         expectResults(expected, done)
@@ -669,18 +669,18 @@ describe('gerber parser with gerber files', function () {
       })
     })
 
-    describe('variable set blocks', function () {
+    describe('variable set blocks', function() {
       var mods
-      beforeEach(function () {
+      beforeEach(function() {
         mods = {$1: 42}
       })
 
-      var expectExprResults = function (expected, done) {
-        p.once('data', function (res) {
+      var expectExprResults = function(expected, done) {
+        p.once('data', function(res) {
           expect(res.type).to.equal('macro')
           expect(res.name).to.equal('MODS1')
 
-          res.blocks.forEach(function (v) {
+          res.blocks.forEach(function(v) {
             var newMods = v.set(mods)
             expect(v.type).to.equal('variable')
             expect(newMods).to.eql(expected.shift())
@@ -690,7 +690,7 @@ describe('gerber parser with gerber files', function () {
         })
       }
 
-      it('should return function that takes / returns mods', function (done) {
+      it('should return function that takes / returns mods', function(done) {
         var expected = [{$1: 42, $2: 1}]
 
         expectExprResults(expected, done)
@@ -698,7 +698,7 @@ describe('gerber parser with gerber files', function () {
         p.write('$2=1*%\n')
       })
 
-      it('should parse addition', function (done) {
+      it('should parse addition', function(done) {
         var expected = [{$1: 42, $2: 3}, {$1: 42, $2: 56}]
 
         expectExprResults(expected, done)
@@ -707,7 +707,7 @@ describe('gerber parser with gerber files', function () {
         p.write('$2=$1+14*%\n')
       })
 
-      it('should parse subtraction', function (done) {
+      it('should parse subtraction', function(done) {
         var expected = [{$1: 42, $2: 3}, {$1: 42, $2: 21}]
 
         expectExprResults(expected, done)
@@ -716,7 +716,7 @@ describe('gerber parser with gerber files', function () {
         p.write('$2=63-$1*%\n')
       })
 
-      it('should parse multiplication with x and X', function (done) {
+      it('should parse multiplication with x and X', function(done) {
         var expected = [{$1: 42, $2: 21}, {$1: 42, $2: 6}]
 
         expectExprResults(expected, done)
@@ -725,8 +725,8 @@ describe('gerber parser with gerber files', function () {
         p.write('$2=2X3*%\n')
       })
 
-      it('should warn that mult with X is incorrect', function (done) {
-        p.once('warning', function (w) {
+      it('should warn that mult with X is incorrect', function(done) {
+        p.once('warning', function(w) {
           expect(w.message).to.match(/multiplication/)
           done()
         })
@@ -735,7 +735,7 @@ describe('gerber parser with gerber files', function () {
         p.write('$2=$1X1*%\n')
       })
 
-      it('should parse division with /', function (done) {
+      it('should parse division with /', function(done) {
         var expected = [{$1: 42, $2: 4}, {$1: 42, $2: 21}]
 
         expectExprResults(expected, done)
@@ -744,7 +744,7 @@ describe('gerber parser with gerber files', function () {
         p.write('$2=$1/2*%\n')
       })
 
-      it('should handle expressions with parentheses', function (done) {
+      it('should handle expressions with parentheses', function(done) {
         var expected = [{$1: 42, $2: 3}]
 
         expectExprResults(expected, done)
@@ -753,8 +753,8 @@ describe('gerber parser with gerber files', function () {
       })
     })
 
-    it('should parse params in primitives as expressions', function (done) {
-      p.once('data', function (d) {
+    it('should parse params in primitives as expressions', function(done) {
+      p.once('data', function(d) {
         expect(d.blocks[0].dia({$1: 4})).to.equal(5)
         done()
       })
@@ -764,24 +764,24 @@ describe('gerber parser with gerber files', function () {
     })
   })
 
-  describe('operations', function () {
-    beforeEach(function () {
+  describe('operations', function() {
+    beforeEach(function() {
       p.format.zero = 'L'
       p.format.places = [2, 3]
     })
 
-    it('should parse an interpolation command', function (done) {
+    it('should parse an interpolation command', function(done) {
       var expected = [
         {
           type: 'op',
           line: 0,
           op: 'int',
-          coord: {x: 0.1, y: 0.2, i: 0.3, j: 0.4}
+          coord: {x: 0.1, y: 0.2, i: 0.3, j: 0.4},
         },
         {type: 'op', line: 1, op: 'int', coord: {x: 0.11, y: 0}},
         {type: 'op', line: 2, op: 'int', coord: {x: 0.22}},
         {type: 'op', line: 3, op: 'int', coord: {y: 0.33}},
-        {type: 'op', line: 4, op: 'int', coord: {}}
+        {type: 'op', line: 4, op: 'int', coord: {}},
       ]
 
       expectResults(expected, done)
@@ -792,11 +792,11 @@ describe('gerber parser with gerber files', function () {
       p.write('D01*\n')
     })
 
-    it('should parse a move command', function (done) {
+    it('should parse a move command', function(done) {
       var expected = [
         {type: 'op', line: 0, op: 'move', coord: {x: 0.3, y: 0.001}},
         {type: 'op', line: 1, op: 'move', coord: {x: -0.1}},
-        {type: 'op', line: 2, op: 'move', coord: {}}
+        {type: 'op', line: 2, op: 'move', coord: {}},
       ]
 
       expectResults(expected, done)
@@ -805,11 +805,11 @@ describe('gerber parser with gerber files', function () {
       p.write('D02*\n')
     })
 
-    it('should parse a flash command', function (done) {
+    it('should parse a flash command', function(done) {
       var expected = [
         {type: 'op', line: 0, op: 'flash', coord: {x: 0.3, y: 0.001}},
         {type: 'op', line: 1, op: 'flash', coord: {x: -0.1}},
-        {type: 'op', line: 2, op: 'flash', coord: {}}
+        {type: 'op', line: 2, op: 'flash', coord: {}},
       ]
 
       expectResults(expected, done)
@@ -818,10 +818,10 @@ describe('gerber parser with gerber files', function () {
       p.write('D03*\n')
     })
 
-    it('should send "last" operation if op code is missing', function (done) {
+    it('should send "last" operation if op code is missing', function(done) {
       var expected = [
         {type: 'op', line: 0, op: 'last', coord: {x: 0.3, y: 0.001}},
-        {type: 'op', line: 1, op: 'last', coord: {x: -0.1}}
+        {type: 'op', line: 1, op: 'last', coord: {x: -0.1}},
       ]
 
       expectResults(expected, done)
@@ -829,14 +829,14 @@ describe('gerber parser with gerber files', function () {
       p.write('X-100*\n')
     })
 
-    it('should interpolate with inline mode set', function (done) {
+    it('should interpolate with inline mode set', function(done) {
       var expected = [
         {type: 'set', line: 0, prop: 'mode', value: 'i'},
         {type: 'op', line: 0, op: 'int', coord: {x: 0.001, y: 0.001}},
         {type: 'set', line: 1, prop: 'mode', value: 'cw'},
         {type: 'op', line: 1, op: 'int', coord: {x: 0.001, y: 0.001}},
         {type: 'set', line: 2, prop: 'mode', value: 'ccw'},
-        {type: 'op', line: 2, op: 'int', coord: {x: 0.001, y: 0.001}}
+        {type: 'op', line: 2, op: 'int', coord: {x: 0.001, y: 0.001}},
       ]
 
       expectResults(expected, done)
@@ -845,8 +845,8 @@ describe('gerber parser with gerber files', function () {
       p.write('G03X01Y01D01*\n')
     })
 
-    it('should be strict about what counts as a operation', function (done) {
-      p.once('readable', function () {
+    it('should be strict about what counts as a operation', function(done) {
+      p.once('readable', function() {
         throw new Error('should not have operated')
       })
 

--- a/packages/gerber-parser/test/gerber-parser_test.js
+++ b/packages/gerber-parser/test/gerber-parser_test.js
@@ -7,112 +7,112 @@ var repeat = require('lodash/repeat')
 
 var parser = require('../lib')
 
-describe('gerber parser', function () {
-  describe('factory and options', function () {
-    it('should return a transform stream', function () {
+describe('gerber parser', function() {
+  describe('factory and options', function() {
+    it('should return a transform stream', function() {
       var p = parser()
       expect(p).to.be.an.instanceOf(Transform)
     })
 
-    it('should allow setting the zero suppression', function () {
+    it('should allow setting the zero suppression', function() {
       var p = parser({zero: 'L'})
       expect(p.format.zero).to.equal('L')
       p = parser({zero: 'T'})
       expect(p.format.zero).to.equal('T')
     })
 
-    it('should allow setting the number places format', function () {
+    it('should allow setting the number places format', function() {
       var p = parser({places: [1, 4]})
       expect(p.format.places).to.eql([1, 4])
       p = parser({places: [3, 4]})
       expect(p.format.places).to.eql([3, 4])
     })
 
-    it('should allow setting the filetype', function () {
+    it('should allow setting the filetype', function() {
       var p = parser({filetype: 'gerber'})
       expect(p.format.filetype).to.equal('gerber')
       p = parser({filetype: 'drill'})
       expect(p.format.filetype).to.equal('drill')
     })
 
-    it('should throw with bad options to the contructor', function () {
+    it('should throw with bad options to the contructor', function() {
       var p
       var badOpts = {places: 'string'}
-      expect(function () {
+      expect(function() {
         p = parser(badOpts)
       }).to.throw(/places/)
       badOpts = {places: [1, 2, 3]}
-      expect(function () {
+      expect(function() {
         p = parser(badOpts)
       }).to.throw(/places/)
       badOpts = {places: ['a', 'b']}
-      expect(function () {
+      expect(function() {
         p = parser(badOpts)
       }).to.throw(/places/)
       badOpts = {zero: 4}
-      expect(function () {
+      expect(function() {
         p = parser(badOpts)
       }).to.throw(/zero/)
       badOpts = {zero: 'F'}
-      expect(function () {
+      expect(function() {
         p = parser(badOpts)
       }).to.throw(/zero/)
       badOpts = {filetype: 'foo'}
-      expect(function () {
+      expect(function() {
         p = parser(badOpts)
       }).to.throw(/type/)
       void p
     })
 
-    it('should not throw with null/undefined options', function () {
+    it('should not throw with null/undefined options', function() {
       var p
-      expect(function () {
+      expect(function() {
         p = parser({places: null})
       }).to.not.throw()
       expect(!!p.format.places).to.equal(false)
 
-      expect(function () {
+      expect(function() {
         p = parser({filetype: undefined})
       }).to.not.throw()
       expect(!!p.format.filetype).to.equal(false)
 
-      expect(function () {
+      expect(function() {
         p = parser({zero: null})
       }).to.not.throw()
       expect(!!p.format.zero).to.equal(false)
     })
   })
 
-  describe('reading files', function () {
+  describe('reading files', function() {
     var p
-    beforeEach(function () {
+    beforeEach(function() {
       p = parser()
     })
 
-    describe('determining filetype', function () {
-      it('should not set any filetype with a blank line', function () {
+    describe('determining filetype', function() {
+      it('should not set any filetype with a blank line', function() {
         p.write('\n')
         expect(p.format.filetype === null).to.equal(true)
         p.write('')
         expect(p.format.filetype === null).to.equal(true)
       })
 
-      it('should set filetype to gerber if it sees a *', function () {
+      it('should set filetype to gerber if it sees a *', function() {
         p.write('*\n')
         expect(p.format.filetype).to.equal('gerber')
       })
 
-      it('should set filetype to drill if line ends without *', function () {
+      it('should set filetype to drill if line ends without *', function() {
         p.write('M48\n')
         expect(p.format.filetype).to.equal('drill')
       })
 
-      it('should ignore a star in a drill comment', function () {
+      it('should ignore a star in a drill comment', function() {
         p.write('; **hey a comment**\n')
         expect(p.format.filetype).to.equal('drill')
       })
 
-      it('should not overwrite a filetype', function () {
+      it('should not overwrite a filetype', function() {
         p.format.filetype = 'gerber'
         p.write('G04 M48\n')
         expect(p.format.filetype).to.equal('gerber')
@@ -122,9 +122,9 @@ describe('gerber parser', function () {
         expect(p.format.filetype).to.equal('drill')
       })
 
-      it('should error if unknown after 65535 characters', function (done) {
+      it('should error if unknown after 65535 characters', function(done) {
         this.timeout(2000)
-        p.once('error', function (error) {
+        p.once('error', function(error) {
           expect(error.message).to.match(/determine filetype/)
           done()
         })
@@ -132,7 +132,7 @@ describe('gerber parser', function () {
         p.write(repeat(';', 65536))
       })
 
-      it('should stash chunks if it cannot make a determination', function () {
+      it('should stash chunks if it cannot make a determination', function() {
         p.write('G04 this line gets split into')
         expect(p._stash).to.equal('G04 this line gets split into')
         p.write('two chunks*\n')
@@ -140,29 +140,29 @@ describe('gerber parser', function () {
       })
     })
 
-    it("should know what line it's on", function () {
+    it("should know what line it's on", function() {
       p.write(repeat('*\n', 5))
       expect(p.line).to.equal(5)
     })
   })
 
-  describe('synchronous parsing', function () {
+  describe('synchronous parsing', function() {
     var p
-    beforeEach(function () {
+    beforeEach(function() {
       p = parser()
     })
 
-    it('should determine filetype for gerbers', function () {
+    it('should determine filetype for gerbers', function() {
       p.parseSync('*\n')
       expect(p.format.filetype).to.equal('gerber')
     })
 
-    it('should determine filetype for drills', function () {
+    it('should determine filetype for drills', function() {
       p.parseSync('; drill comment\n')
       expect(p.format.filetype).to.equal('drill')
     })
 
-    it('should read a whole gerber file', function () {
+    it('should read a whole gerber file', function() {
       var gerber = ['G04 a comment*', 'G04 another comment*', 'M02*', ''].join(
         '\n'
       )
@@ -172,7 +172,7 @@ describe('gerber parser', function () {
       expect(result).to.have.lengthOf(1)
     })
 
-    it('should read a whole drill file', function () {
+    it('should read a whole drill file', function() {
       var drill = ['; a comment', '; another comment', 'M00', ''].join('\n')
 
       var result = p.parseSync(drill)

--- a/packages/gerber-parser/test/get-next-block_test.js
+++ b/packages/gerber-parser/test/get-next-block_test.js
@@ -5,25 +5,25 @@ var expect = require('chai').expect
 var partial = require('lodash/partial')
 var getNextBlock = require('../lib/get-next-block')
 
-describe('get next block', function () {
-  it('should throw with a bad filetype', function () {
-    var bad = function () {
+describe('get next block', function() {
+  it('should throw with a bad filetype', function() {
+    var bad = function() {
       getNextBlock('foo', '', 0)
     }
     expect(bad).to.throw(/filetype/)
   })
 
-  describe('from gerber files', function () {
+  describe('from gerber files', function() {
     var getNext = partial(getNextBlock, 'gerber')
 
-    it('should split at *', function () {
+    it('should split at *', function() {
       var chunk = 'M02*'
       var result = getNext(chunk, 0)
 
       expect(result.block).to.equal('M02')
     })
 
-    it('should return characters read', function () {
+    it('should return characters read', function() {
       var chunk = 'G01*G02*G03*'
       var res1 = getNext(chunk, 0)
       var res2 = getNext(chunk, 4)
@@ -37,7 +37,7 @@ describe('get next block', function () {
       expect(res3.read).to.equal(4)
     })
 
-    it('should return newlines read', function () {
+    it('should return newlines read', function() {
       var chunk = 'G01*\nG02*\nG03*\n'
       var res1 = getNext(chunk, 0)
       var res2 = getNext(chunk, 4)
@@ -54,7 +54,7 @@ describe('get next block', function () {
       expect(res3.lines).to.equal(1)
     })
 
-    it('should skip the end percent of a param', function () {
+    it('should skip the end percent of a param', function() {
       var chunk = '%FSLAX24Y24*%\n%MOIN*%\n'
       var res1 = getNext(chunk, 0)
       var res2 = getNext(chunk, 13)
@@ -67,7 +67,7 @@ describe('get next block', function () {
       expect(res2.lines).to.equal(1)
     })
 
-    it('should trim whitespace between blocks', function () {
+    it('should trim whitespace between blocks', function() {
       var chunk = 'G04 hello*  \n%FSLAX24Y24*%\n'
       var res1 = getNext(chunk, 0)
       var res2 = getNext(chunk, res1.read)
@@ -81,10 +81,10 @@ describe('get next block', function () {
     })
   })
 
-  describe('from drill files', function () {
+  describe('from drill files', function() {
     var getNext = partial(getNextBlock, 'drill')
 
-    it('should split at newlines', function () {
+    it('should split at newlines', function() {
       var chunk = 'G90\nG05\nM72\nM30\n'
       var res1 = getNext(chunk, 0)
       var res2 = getNext(chunk, 4)

--- a/packages/gerber-parser/test/normalize-coord_test.js
+++ b/packages/gerber-parser/test/normalize-coord_test.js
@@ -6,8 +6,8 @@ var expect = require('chai').expect
 var isNaN = require('lodash/isNaN')
 var normalize = require('../lib/normalize-coord')
 
-describe('normalize coordinate', function () {
-  it('should return NaN for bad input', function () {
+describe('normalize coordinate', function() {
+  it('should return NaN for bad input', function() {
     expect(isNaN(normalize())).to.equal(true)
     expect(isNaN(normalize('0.1.2'))).to.equal(true)
     expect(isNaN(normalize('45', {zero: 'L'}))).to.equal(true)
@@ -19,21 +19,21 @@ describe('normalize coordinate', function () {
     )
   })
 
-  it('should convert decimal numbers into proper coords', function () {
+  it('should convert decimal numbers into proper coords', function() {
     expect(normalize('1.3')).to.equal(1.3)
     expect(normalize('-.343')).to.equal(-0.343)
     expect(normalize('+4.3478')).to.equal(4.3478)
     expect(normalize('10')).to.equal(10)
   })
 
-  it('should convert trailing zero suppressed numbers into proper coords', function () {
+  it('should convert trailing zero suppressed numbers into proper coords', function() {
     expect(normalize('13', {places: [2, 4], zero: 'T'})).to.equal(13)
     expect(normalize('-343', {places: [2, 3], zero: 'T'})).to.equal(-34.3)
     expect(normalize('+4347', {places: [2, 2], zero: 'T'})).to.equal(43.47)
     expect(normalize('1', {places: [2, 4], zero: 'T'})).to.equal(10)
   })
 
-  it('should convert leading zero suppressed numbers into proper coords', function () {
+  it('should convert leading zero suppressed numbers into proper coords', function() {
     expect(normalize('13', {places: [2, 4], zero: 'L'})).to.equal(0.0013)
     expect(normalize('-343', {places: [2, 3], zero: 'L'})).to.equal(-0.343)
     expect(normalize('+4347', {places: [2, 2], zero: 'L'})).to.equal(43.47)

--- a/packages/gerber-parser/test/parse-coord_test.js
+++ b/packages/gerber-parser/test/parse-coord_test.js
@@ -7,14 +7,14 @@ var parseCoord = require('../lib/parse-coord')
 // svg coordinate FACTOR
 var FORMAT = {places: [2, 3], zeros: null}
 
-describe('coordinate parser', function () {
-  it('should throw if passed an incorrect format', function () {
-    expect(function () {
+describe('coordinate parser', function() {
+  it('should throw if passed an incorrect format', function() {
+    expect(function() {
       parseCoord.parse('X1Y1', {})
     }).to.throw(/format undefined/)
   })
 
-  it('should parse properly with leading zero suppression', function () {
+  it('should parse properly with leading zero suppression', function() {
     FORMAT.zero = 'L'
     expect(parseCoord.parse('X10', FORMAT)).to.eql({x: 0.01})
     expect(parseCoord.parse('Y15', FORMAT)).to.eql({y: 0.015})
@@ -24,11 +24,11 @@ describe('coordinate parser', function () {
       x: 1,
       y: -2,
       i: 0.003,
-      j: 0.432
+      j: 0.432,
     })
   })
 
-  it('should parse properly with trailing zero suppression', function () {
+  it('should parse properly with trailing zero suppression', function() {
     FORMAT.zero = 'T'
     expect(parseCoord.parse('X10', FORMAT)).to.eql({x: 10})
     expect(parseCoord.parse('Y15', FORMAT)).to.eql({y: 15})
@@ -38,11 +38,11 @@ describe('coordinate parser', function () {
       x: 0.01,
       y: -0.02,
       i: 30,
-      j: 43.2
+      j: 43.2,
     })
   })
 
-  it('should parse properly with explicit decimals mixed in', function () {
+  it('should parse properly with explicit decimals mixed in', function() {
     FORMAT.zero = 'L'
     expect(parseCoord.parse('X1.1', FORMAT)).to.eql({x: 1.1})
     expect(parseCoord.parse('Y1.5', FORMAT)).to.eql({y: 1.5})
@@ -52,29 +52,29 @@ describe('coordinate parser', function () {
       x: 1.1,
       y: -2.02,
       i: 3.3,
-      j: 43.2
+      j: 43.2,
     })
   })
 
-  it('should return an empty object if no string is passed in', function () {
+  it('should return an empty object if no string is passed in', function() {
     expect(parseCoord.parse()).to.eql({})
   })
 })
 
-describe('zero detection', function () {
-  it('should detect leading zero supression', function () {
+describe('zero detection', function() {
+  it('should detect leading zero supression', function() {
     expect(parseCoord.detectZero('X10Y10')).to.eql('L')
   })
 
-  it('should detect trailing zero supression', function () {
+  it('should detect trailing zero supression', function() {
     expect(parseCoord.detectZero('X01Y001')).to.eql('T')
   })
 
-  it('should return null when not detectable', function () {
+  it('should return null when not detectable', function() {
     expect(parseCoord.detectZero('X1Y1')).to.eql(null)
   })
 
-  it('should return null when a decimal', function () {
+  it('should return null when a decimal', function() {
     expect(parseCoord.detectZero('X0.1Y1.0')).to.eql(null)
   })
 })

--- a/packages/gerber-plotter/integration/gerber-plotter-snapshot.test.js
+++ b/packages/gerber-plotter/integration/gerber-plotter-snapshot.test.js
@@ -8,13 +8,13 @@ const getResults = require('./get-results')
 
 const SUITES = [...getBoards.sync().filter(b => !b.skipSnapshot)]
 
-describe(`gerber-plotter :: integration`, function () {
+describe(`gerber-plotter :: integration`, function() {
   SUITES.forEach(suite =>
-    describe(suite.name, function () {
+    describe(suite.name, function() {
       const specs = suite.specs || suite.layers
       let suiteResults
 
-      before(function (done) {
+      before(function(done) {
         if (process.env.INTEGRATION !== '1') return this.skip()
 
         getResults(suite, (error, results) => {
@@ -25,7 +25,7 @@ describe(`gerber-plotter :: integration`, function () {
       })
 
       specs.forEach((spec, i) =>
-        it(`renders ${spec.name}`, function () {
+        it(`renders ${spec.name}`, function() {
           snapshot(suiteResults.specs[i].render)
         })
       )

--- a/packages/gerber-plotter/integration/get-results.js
+++ b/packages/gerber-plotter/integration/get-results.js
@@ -12,7 +12,7 @@ const gerberParser = require('gerber-parser')
 const gerberPlotter = require('gerber-plotter')
 const wtg = require('whats-that-gerber')
 
-module.exports = function getSuiteResults (suite, done) {
+module.exports = function getSuiteResults(suite, done) {
   debug(`Rendering suite ${suite.name}`)
 
   const specs = suite.specs || suite.layers
@@ -21,18 +21,18 @@ module.exports = function getSuiteResults (suite, done) {
   runWaterfall(
     [
       next => runParallel(specTasks, next),
-      (specs, next) => next(null, Object.assign(suite, {specs}))
+      (specs, next) => next(null, Object.assign(suite, {specs})),
     ],
     done
   )
 }
 
-function renderSpec (spec, done) {
+function renderSpec(spec, done) {
   debug(`Rendering ${spec.category} - ${spec.name}`)
 
   const renderOptions = Object.assign(
     {
-      plotAsOutline: spec.type === wtg.TYPE_OUTLINE
+      plotAsOutline: spec.type === wtg.TYPE_OUTLINE,
     },
     spec.options
   )
@@ -46,7 +46,7 @@ function renderSpec (spec, done) {
   runWaterfall(
     [
       next => pump(source, parser, plotter, dest, next),
-      next => next(null, Object.assign({render}, spec))
+      next => next(null, Object.assign({render}, spec)),
     ],
     done
   )

--- a/packages/gerber-plotter/lib/_box.js
+++ b/packages/gerber-plotter/lib/_box.js
@@ -3,42 +3,42 @@
 'use strict'
 
 // returns a new bounding box that is infinitely small and centered on nothing
-var newBox = function () {
+var newBox = function() {
   return [Infinity, Infinity, -Infinity, -Infinity]
 }
 
 // adds the two bounding boxes and returns a new one
-var add = function (box, target) {
+var add = function(box, target) {
   return [
     Math.min(box[0], target[0]),
     Math.min(box[1], target[1]),
     Math.max(box[2], target[2]),
-    Math.max(box[3], target[3])
+    Math.max(box[3], target[3]),
   ]
 }
 
 // adds a point to a bounding box
-var addPoint = function (box, point) {
+var addPoint = function(box, point) {
   return [
     Math.min(box[0], point[0]),
     Math.min(box[1], point[1]),
     Math.max(box[2], point[0]),
-    Math.max(box[3], point[1])
+    Math.max(box[3], point[1]),
   ]
 }
 
 // add a circle at (cx, cy) with radius r to box
-var addCircle = function (box, r, cx, cy) {
+var addCircle = function(box, r, cx, cy) {
   return [
     Math.min(box[0], cx - r),
     Math.min(box[1], cy - r),
     Math.max(box[2], cx + r),
-    Math.max(box[3], cy + r)
+    Math.max(box[3], cy + r),
   ]
 }
 
 // translate a box by a delta [x, y]
-var translate = function (box, delta) {
+var translate = function(box, delta) {
   var dx = delta[0]
   var dy = delta[1]
 
@@ -46,7 +46,7 @@ var translate = function (box, delta) {
 }
 
 // get the overall box if box is repeated at [x, y]
-var repeat = function (box, repeat) {
+var repeat = function(box, repeat) {
   return add(box, translate(box, repeat))
 }
 
@@ -56,5 +56,5 @@ module.exports = {
   addPoint: addPoint,
   addCircle: addCircle,
   translate: translate,
-  repeat: repeat
+  repeat: repeat,
 }

--- a/packages/gerber-plotter/lib/_operate.js
+++ b/packages/gerber-plotter/lib/_operate.js
@@ -6,11 +6,11 @@ var boundingBox = require('./_box')
 var HALF_PI = Math.PI / 2
 var PI = Math.PI
 var TWO_PI = Math.PI * 2
-var THREE_HALF_PI = 3 * Math.PI / 2
+var THREE_HALF_PI = (3 * Math.PI) / 2
 
 // flash operation
 // returns a bounding box for the operation
-var flash = function (coord, tool, region, plotter) {
+var flash = function(coord, tool, region, plotter) {
   // no flashing allowed in region mode
   if (region) {
     plotter._warn('flash in region ignored')
@@ -35,7 +35,7 @@ var flash = function (coord, tool, region, plotter) {
 
 // given a start, end, direction, arc quadrant mode, and list of potential centers, find the
 // angles of the start and end points, the sweep angle, and the center
-var findCenterAndAngles = function (start, end, mode, arc, centers) {
+var findCenterAndAngles = function(start, end, mode, arc, centers) {
   var thetaStart
   var thetaEnd
   var sweep
@@ -81,11 +81,11 @@ var findCenterAndAngles = function (start, end, mode, arc, centers) {
     center: center,
     sweep: sweep,
     start: start.concat(thetaStart),
-    end: end.concat(thetaEnd)
+    end: end.concat(thetaEnd),
   }
 }
 
-var arcBox = function (cenAndAngles, r, region, tool, dir) {
+var arcBox = function(cenAndAngles, r, region, tool, dir) {
   var startPoint = cenAndAngles.start
   var endPoint = cenAndAngles.end
   var center = cenAndAngles.center
@@ -132,7 +132,7 @@ var arcBox = function (cenAndAngles, r, region, tool, dir) {
     points.push([center[0], center[1] - r])
   }
 
-  return points.reduce(function (result, m) {
+  return points.reduce(function(result, m) {
     if (!region) {
       var mBox = boundingBox.translate(tool.box, m)
       return boundingBox.add(result, mBox)
@@ -142,14 +142,14 @@ var arcBox = function (cenAndAngles, r, region, tool, dir) {
   }, boundingBox.new())
 }
 
-var roundToZero = function (number, epsilon) {
+var roundToZero = function(number, epsilon) {
   return number >= epsilon ? number : 0
 }
 
 // find the center of an arc given its endpoints and its radius
 // assume the arc is <= 180 degress
 // thank you this guy: http://math.stackexchange.com/a/87912
-var arcCenterFromRadius = function (start, end, mode, epsilon, radius) {
+var arcCenterFromRadius = function(start, end, mode, epsilon, radius) {
   var sign = mode === 'ccw' ? 1 : -1
   var xAve = (start[0] + end[0]) / 2
   var yAve = (start[1] + end[1]) / 2
@@ -160,18 +160,18 @@ var arcCenterFromRadius = function (start, end, mode, epsilon, radius) {
   var squareDifference = Math.sqrt(
     Math.pow(radius, 2) - Math.pow(halfDistance, 2)
   )
-  var xOffset = -sign * deltaY * squareDifference / distance
-  var yOffset = sign * deltaX * squareDifference / distance
+  var xOffset = (-sign * deltaY * squareDifference) / distance
+  var yOffset = (sign * deltaX * squareDifference) / distance
 
   return [
     [
       roundToZero(xAve + xOffset, epsilon),
-      roundToZero(yAve + yOffset, epsilon)
-    ]
+      roundToZero(yAve + yOffset, epsilon),
+    ],
   ]
 }
 
-var drawArc = function (
+var drawArc = function(
   start,
   end,
   offset,
@@ -217,7 +217,7 @@ var drawArc = function (
     arc = 'm'
     validCenters = arcCenterFromRadius(start, end, mode, epsilon, offset[2])
   } else if (arc === 's') {
-    validCenters = candidates.filter(function (c) {
+    validCenters = candidates.filter(function(c) {
       var startDist = Math.sqrt(
         Math.pow(c[0] - start[0], 2) + Math.pow(c[1] - start[1], 2)
       )
@@ -249,7 +249,7 @@ var drawArc = function (
       center: cenAndAngles.center,
       sweep: cenAndAngles.sweep,
       radius: r,
-      dir: mode
+      dir: mode,
     })
 
     box = arcBox(cenAndAngles, r, region, tool, mode)
@@ -260,7 +260,7 @@ var drawArc = function (
   return box
 }
 
-var drawLine = function (start, end, tool, region, pathGraph) {
+var drawLine = function(start, end, tool, region, pathGraph) {
   pathGraph.add({type: 'line', start: start, end: end})
 
   if (!region) {
@@ -276,7 +276,7 @@ var drawLine = function (start, end, tool, region, pathGraph) {
 }
 
 // interpolate a rectangle and emit the fill immdeiately
-var interpolateRect = function (start, end, tool, pathGraph, plotter) {
+var interpolateRect = function(start, end, tool, pathGraph, plotter) {
   var hWidth = tool.trace[0] / 2
   var hHeight = tool.trace[1] / 2
   var theta = Math.atan2(end[1] - start[1], end[0] - start[0])
@@ -337,7 +337,7 @@ var interpolateRect = function (start, end, tool, pathGraph, plotter) {
     )
   }
 
-  points.forEach(function (p, i) {
+  points.forEach(function(p, i) {
     var j = i < points.length - 1 ? i + 1 : 0
     pathGraph.add({type: 'line', start: p, end: points[j]})
   })
@@ -352,7 +352,7 @@ var interpolateRect = function (start, end, tool, pathGraph, plotter) {
 
 // interpolate operation
 // returns a bounding box for the operation
-var interpolate = function (
+var interpolate = function(
   start,
   end,
   offset,
@@ -403,7 +403,7 @@ var interpolate = function (
 
 // takes the start point, the op type, the op coords, the tool, and the push function
 // returns the new plotter position
-var operate = function (
+var operate = function(
   type,
   coord,
   start,
@@ -417,13 +417,13 @@ var operate = function (
 ) {
   var end = [
     coord.x != null ? coord.x : start[0],
-    coord.y != null ? coord.y : start[1]
+    coord.y != null ? coord.y : start[1],
   ]
 
   var offset = [
     coord.i != null ? coord.i : 0,
     coord.j != null ? coord.j : 0,
-    coord.a
+    coord.a,
   ]
 
   var box
@@ -454,7 +454,7 @@ var operate = function (
 
   return {
     pos: end,
-    box: box
+    box: box,
   }
 }
 

--- a/packages/gerber-plotter/lib/_pad-shape.js
+++ b/packages/gerber-plotter/lib/_pad-shape.js
@@ -6,7 +6,7 @@ var isFinite = require('lodash.isfinite')
 
 var boundingBox = require('./_box')
 
-var roundToPrecision = function (number) {
+var roundToPrecision = function(number) {
   var rounded = Math.round(number * 100000000) / 100000000
   // remove -0 for ease
   if (rounded === 0) {
@@ -15,11 +15,11 @@ var roundToPrecision = function (number) {
   return rounded
 }
 
-var degreesToRadians = function (degrees) {
-  return degrees * Math.PI / 180
+var degreesToRadians = function(degrees) {
+  return (degrees * Math.PI) / 180
 }
 
-var rotatePointAboutOrigin = function (point, rot) {
+var rotatePointAboutOrigin = function(point, rot) {
   rot = degreesToRadians(rot)
   var sin = Math.sin(rot)
   var cos = Math.cos(rot)
@@ -28,11 +28,11 @@ var rotatePointAboutOrigin = function (point, rot) {
 
   return [
     roundToPrecision(x * cos - y * sin),
-    roundToPrecision(x * sin + y * cos)
+    roundToPrecision(x * sin + y * cos),
   ]
 }
 
-var circle = function (dia, cx, cy, rot) {
+var circle = function(dia, cx, cy, rot) {
   var r = dia / 2
   cx = cx || 0
   cy = cy || 0
@@ -46,11 +46,11 @@ var circle = function (dia, cx, cy, rot) {
 
   return {
     shape: {type: 'circle', cx: cx, cy: cy, r: dia / 2},
-    box: boundingBox.addCircle(boundingBox.new(), r, cx, cy)
+    box: boundingBox.addCircle(boundingBox.new(), r, cx, cy),
   }
 }
 
-var vect = function (x1, y1, x2, y2, width, rot) {
+var vect = function(x1, y1, x2, y2, width, rot) {
   // rotate the endpoints if necessary
   if (rot) {
     var start = rotatePointAboutOrigin([x1, y1], rot)
@@ -79,17 +79,17 @@ var vect = function (x1, y1, x2, y2, width, rot) {
   points.push([roundToPrecision(x2 - sin), roundToPrecision(y2 + cos)])
   points.push([roundToPrecision(x1 - sin), roundToPrecision(y1 + cos)])
 
-  var box = points.reduce(function (result, p) {
+  var box = points.reduce(function(result, p) {
     return boundingBox.addPoint(result, p)
   }, boundingBox.new())
 
   return {
     shape: {type: 'poly', points: points},
-    box: box
+    box: box,
   }
 }
 
-var rect = function (width, height, r, cx, cy, rot) {
+var rect = function(width, height, r, cx, cy, rot) {
   cx = cx || 0
   cy = cy || 0
   r = r || 0
@@ -109,11 +109,11 @@ var rect = function (width, height, r, cx, cy, rot) {
 
   return {
     shape: {type: 'rect', cx: cx, cy: cy, r: r, width: width, height: height},
-    box: [-hWidth + cx, -hHeight + cy, hWidth + cx, hHeight + cy]
+    box: [-hWidth + cx, -hHeight + cy, hWidth + cx, hHeight + cy],
   }
 }
 
-var outlinePolygon = function (flatPoints, rot) {
+var outlinePolygon = function(flatPoints, rot) {
   var points = []
   var box = boundingBox.new()
   var point
@@ -129,11 +129,11 @@ var outlinePolygon = function (flatPoints, rot) {
 
   return {
     shape: {type: 'poly', points: points},
-    box: box
+    box: box,
   }
 }
 
-var regularPolygon = function (dia, nPoints, rot, cx, cy) {
+var regularPolygon = function(dia, nPoints, rot, cx, cy) {
   cx = cx || 0
   cy = cy || 0
 
@@ -141,8 +141,8 @@ var regularPolygon = function (dia, nPoints, rot, cx, cy) {
   var box = boundingBox.new()
 
   var r = dia / 2
-  var offset = rot * Math.PI / 180
-  var step = 2 * Math.PI / nPoints
+  var offset = (rot * Math.PI) / 180
+  var step = (2 * Math.PI) / nPoints
   var theta
   var x
   var y
@@ -157,16 +157,16 @@ var regularPolygon = function (dia, nPoints, rot, cx, cy) {
 
   return {
     shape: {type: 'poly', points: points},
-    box: box
+    box: box,
   }
 }
 
 // just returns a ring object, does not return a box
-var ring = function (cx, cy, r, width) {
+var ring = function(cx, cy, r, width) {
   return {type: 'ring', cx: cx, cy: cy, r: r, width: width}
 }
 
-var moire = function (
+var moire = function(
   dia,
   ringThx,
   ringGap,
@@ -206,7 +206,7 @@ var moire = function (
   return {shape: shape, box: box}
 }
 
-var thermal = function (cx, cy, outerDia, innerDia, gap, rot) {
+var thermal = function(cx, cy, outerDia, innerDia, gap, rot) {
   var side = roundToPrecision((outerDia - gap) / 2)
   var offset = roundToPrecision((outerDia + gap) / 4)
   var width = roundToPrecision((outerDia - innerDia) / 2)
@@ -217,27 +217,27 @@ var thermal = function (cx, cy, outerDia, innerDia, gap, rot) {
     rect(side, side, 0, cx + offset, cy + offset, rot).shape,
     rect(side, side, 0, cx - offset, cy + offset, rot).shape,
     rect(side, side, 0, cx - offset, cy - offset, rot).shape,
-    rect(side, side, 0, cx + offset, cy - offset, rot).shape
+    rect(side, side, 0, cx + offset, cy - offset, rot).shape,
   ]
   var clip = ring(cx, cy, r, width)
 
   return {
     shape: {type: 'clip', shape: rects, clip: clip},
-    box: box
+    box: box,
   }
 }
 
-var runMacro = function (mods, blocks) {
+var runMacro = function(mods, blocks) {
   var emptyMacro = {shape: [], box: boundingBox.new()}
   var exposure = 1
 
   blocks = blocks || []
 
-  return blocks.reduce(function (result, block) {
+  return blocks.reduce(function(result, block) {
     var shapeAndBox
 
     if (block.type !== 'variable' && block.type !== 'comment') {
-      block = Object.keys(block).reduce(function (result, key) {
+      block = Object.keys(block).reduce(function(result, key) {
         var value = block[key]
 
         if (isFunction(value)) {
@@ -254,7 +254,7 @@ var runMacro = function (mods, blocks) {
       result.shape.push({
         type: 'layer',
         polarity: block.exp === 1 ? 'dark' : 'clear',
-        box: result.box.slice(0)
+        box: result.box.slice(0),
       })
       exposure = block.exp
     }
@@ -352,7 +352,7 @@ var runMacro = function (mods, blocks) {
   }, emptyMacro)
 }
 
-module.exports = function padShape (tool, macros) {
+module.exports = function padShape(tool, macros) {
   var shape = []
   var box = boundingBox.new()
   var toolShape = tool.shape
@@ -370,7 +370,7 @@ module.exports = function padShape (tool, macros) {
     shapeAndBox = regularPolygon(params[0], params[1], params[2])
   } else {
     // else we got a macro, so run the macro and return
-    var mods = params.reduce(function (result, val, index) {
+    var mods = params.reduce(function(result, val, index) {
       result['$' + (index + 1)] = val
 
       return result

--- a/packages/gerber-plotter/lib/_warning.js
+++ b/packages/gerber-plotter/lib/_warning.js
@@ -1,7 +1,7 @@
 // simple warning
 'use strict'
 
-var warning = function (message, line) {
+var warning = function(message, line) {
   return {message: message, line: line}
 }
 

--- a/packages/gerber-plotter/lib/index.js
+++ b/packages/gerber-plotter/lib/index.js
@@ -3,7 +3,7 @@
 
 var Plotter = require('./plotter')
 
-var verifyNota = function (nota) {
+var verifyNota = function(nota) {
   if (nota === 'A' || nota === 'I') {
     return nota
   }
@@ -11,7 +11,7 @@ var verifyNota = function (nota) {
   throw new Error('notation must be "in" or "mm"')
 }
 
-var verifyUnits = function (units) {
+var verifyUnits = function(units) {
   if (units === 'in' || units === 'mm') {
     return units
   }
@@ -19,7 +19,7 @@ var verifyUnits = function (units) {
   throw new Error('units must be "in" or "mm"')
 }
 
-module.exports = function plotterFactory (options) {
+module.exports = function plotterFactory(options) {
   options = options || {}
 
   var units = options.units ? verifyUnits(options.units) : null

--- a/packages/gerber-plotter/lib/path-graph.js
+++ b/packages/gerber-plotter/lib/path-graph.js
@@ -3,7 +3,7 @@
 
 var fill = require('lodash.fill')
 
-var find = function (collection, condition) {
+var find = function(collection, condition) {
   var element
   var i
 
@@ -16,9 +16,9 @@ var find = function (collection, condition) {
   }
 }
 
-var findClosest = function (points, position, fillGaps) {
+var findClosest = function(points, position, fillGaps) {
   var result = points.reduce(
-    function (prev, point) {
+    function(prev, point) {
       var d = distance(position, point.position)
       if (d < fillGaps && d < prev.distance) {
         return {point: point, distance: d}
@@ -31,17 +31,17 @@ var findClosest = function (points, position, fillGaps) {
   return result.point
 }
 
-var distance = function (point, target) {
+var distance = function(point, target) {
   return Math.sqrt(
     Math.pow(point[0] - target[0], 2) + Math.pow(point[1] - target[1], 2)
   )
 }
 
-var pointsEqual = function (point, target) {
+var pointsEqual = function(point, target) {
   return point[0] === target[0] && point[1] === target[1]
 }
 
-var lineSegmentsEqual = function (segment, target) {
+var lineSegmentsEqual = function(segment, target) {
   return (
     segment.type === 'line' &&
     ((pointsEqual(segment.start, target.start) &&
@@ -51,7 +51,7 @@ var lineSegmentsEqual = function (segment, target) {
   )
 }
 
-var reverseSegment = function (segment) {
+var reverseSegment = function(segment) {
   var reversed = {type: segment.type, start: segment.end, end: segment.start}
 
   if (segment.type === 'arc') {
@@ -64,29 +64,29 @@ var reverseSegment = function (segment) {
   return reversed
 }
 
-var PathGraph = function (optimize, fillGaps) {
+var PathGraph = function(optimize, fillGaps) {
   this._edges = []
   this._optimize = optimize
   this._fillGaps = fillGaps
   this.length = 0
 }
 
-PathGraph.prototype.add = function (newSeg) {
+PathGraph.prototype.add = function(newSeg) {
   var edge = {segment: newSeg, start: newSeg.start, end: newSeg.end}
   this._edges.push(edge)
   this.length++
 }
 
-PathGraph.prototype._fillGapsAndOptimize = function () {
-  var newSegs = this._edges.map(function (x) {
+PathGraph.prototype._fillGapsAndOptimize = function() {
+  var newSegs = this._edges.map(function(x) {
     return x.segment
   })
   this._edges = []
   this.length = 0
-  var points = newSegs.reduce(function (prev, seg) {
+  var points = newSegs.reduce(function(prev, seg) {
     return prev.concat([
       {position: seg.start, edges: []},
-      {position: seg.end, edges: []}
+      {position: seg.end, edges: []},
     ])
   }, [])
 
@@ -120,7 +120,7 @@ PathGraph.prototype._fillGapsAndOptimize = function () {
     }
 
     // do not allow duplicate line segments
-    var existing = find(this._edges, function (edge) {
+    var existing = find(this._edges, function(edge) {
       return lineSegmentsEqual(edge.segment, newSeg)
     })
 
@@ -142,8 +142,8 @@ PathGraph.prototype._fillGapsAndOptimize = function () {
   // traversal. depth first traversal is used so that when converted to an SVG
   // path it retains its shape. see discussion:
   // https://github.com/mcous/gerber-plotter/pull/13
-  this._edges.forEach(function (edge) {
-    points.forEach(function (point) {
+  this._edges.forEach(function(edge) {
+    points.forEach(function(point) {
       if (pointsEqual(point.position, edge.start.position)) {
         edge.start.edges = edge.start.edges.concat(point.edges)
       }
@@ -154,9 +154,9 @@ PathGraph.prototype._fillGapsAndOptimize = function () {
   })
 }
 
-PathGraph.prototype.traverse = function () {
+PathGraph.prototype.traverse = function() {
   if (!this._optimize) {
-    return this._edges.map(function (edge) {
+    return this._edges.map(function(edge) {
       return edge.segment
     })
   }
@@ -195,7 +195,7 @@ PathGraph.prototype.traverse = function () {
         }
 
         // add non-walked adjacent nodes to the discovered stack
-        lastEnd.edges.reverse().forEach(function (seg) {
+        lastEnd.edges.reverse().forEach(function(seg) {
           if (!walked[seg]) {
             discovered.push(seg)
           }

--- a/packages/gerber-plotter/lib/plotter.js
+++ b/packages/gerber-plotter/lib/plotter.js
@@ -12,7 +12,7 @@ var boundingBox = require('./_box')
 
 var MAX_GAP = 0.00011
 
-var isFormatKey = function (key) {
+var isFormatKey = function(key) {
   return (
     key === 'units' ||
     key === 'backupUnits' ||
@@ -21,7 +21,7 @@ var isFormatKey = function (key) {
   )
 }
 
-var Plotter = function (
+var Plotter = function(
   units,
   backupUnits,
   nota,
@@ -31,21 +31,21 @@ var Plotter = function (
 ) {
   Transform.call(this, {
     readableObjectMode: true,
-    writableObjectMode: true
+    writableObjectMode: true,
   })
 
   this.format = {
     units: units,
     backupUnits: backupUnits || 'in',
     nota: nota,
-    backupNota: backupNota || 'A'
+    backupNota: backupNota || 'A',
   }
 
   this._formatLock = {
     units: units != null,
     backupUnits: backupUnits != null,
     nota: nota != null,
-    backupNota: backupNota != null
+    backupNota: backupNota != null,
   }
 
   this._plotAsOutline = plotAsOutline === true ? MAX_GAP : plotAsOutline
@@ -76,7 +76,7 @@ var Plotter = function (
 
 inherits(Plotter, Transform)
 
-Plotter.prototype._finishPath = function (doNotOptimize) {
+Plotter.prototype._finishPath = function(doNotOptimize) {
   var path = this._path.traverse()
   this._path = new PathGraph(
     !doNotOptimize && this._optimizePaths,
@@ -95,11 +95,11 @@ Plotter.prototype._finishPath = function (doNotOptimize) {
   }
 }
 
-Plotter.prototype._warn = function (message) {
+Plotter.prototype._warn = function(message) {
   this.emit('warning', warning(message, this._line))
 }
 
-Plotter.prototype._checkFormat = function () {
+Plotter.prototype._checkFormat = function() {
   if (!this.format.units) {
     this.format.units = this.format.backupUnits
     this._warn('units not set; using backup units: ' + this.format.units)
@@ -111,7 +111,7 @@ Plotter.prototype._checkFormat = function () {
   }
 }
 
-Plotter.prototype._updateBox = function (box) {
+Plotter.prototype._updateBox = function(box) {
   var stepRepLen = this._stepRep.length
   if (!stepRepLen) {
     this._box = boundingBox.add(this._box, box)
@@ -121,7 +121,7 @@ Plotter.prototype._updateBox = function (box) {
   }
 }
 
-Plotter.prototype._transform = function (chunk, encoding, done) {
+Plotter.prototype._transform = function(chunk, encoding, done) {
   var type = chunk.type
   this._line = chunk.line
 
@@ -141,7 +141,7 @@ Plotter.prototype._transform = function (chunk, encoding, done) {
     if (this.nota === 'I') {
       var _this = this
 
-      coord = Object.keys(coord).reduce(function (result, key) {
+      coord = Object.keys(coord).reduce(function(result, key) {
         var value = coord[key]
 
         if (key === 'x') {
@@ -240,7 +240,7 @@ Plotter.prototype._transform = function (chunk, encoding, done) {
       trace: [],
       pad: shapeAndBox.shape,
       flashed: false,
-      box: shapeAndBox.box
+      box: shapeAndBox.box,
     }
 
     if (toolDef.shape === 'circle' || toolDef.shape === 'rect') {
@@ -266,7 +266,7 @@ Plotter.prototype._transform = function (chunk, encoding, done) {
       this.push({
         type: 'polarity',
         polarity: levelValue === 'C' ? 'clear' : 'dark',
-        box: this._box.slice(0)
+        box: this._box.slice(0),
       })
     } else {
       // calculate new offsets
@@ -281,7 +281,7 @@ Plotter.prototype._transform = function (chunk, encoding, done) {
       this.push({
         type: 'repeat',
         offsets: this._stepRep.slice(0),
-        box: this._box.slice(0)
+        box: this._box.slice(0),
       })
     }
   } else if (type === 'done') {
@@ -291,7 +291,7 @@ Plotter.prototype._transform = function (chunk, encoding, done) {
   return done()
 }
 
-Plotter.prototype._flush = function (done) {
+Plotter.prototype._flush = function(done) {
   this._finishPath()
 
   this.push({type: 'size', box: this._box, units: this.format.units})

--- a/packages/gerber-plotter/test/gerber-plotter_test.js
+++ b/packages/gerber-plotter/test/gerber-plotter_test.js
@@ -9,131 +9,131 @@ var boundingBox = require('../lib/_box')
 
 var EPSILON = 0.000001
 
-describe('gerber plotter', function () {
+describe('gerber plotter', function() {
   var p
-  beforeEach(function () {
+  beforeEach(function() {
     p = plotter()
   })
 
-  it('should be an object stream', function () {
-    expect(function () {
+  it('should be an object stream', function() {
+    expect(function() {
       p.write({})
     }).to.not.throw()
   })
 
-  describe('format options', function () {
-    it('should allow user to set units', function () {
+  describe('format options', function() {
+    it('should allow user to set units', function() {
       p = plotter({units: 'mm'})
       expect(p.format.units).to.equal('mm')
       p = plotter({units: 'in'})
       expect(p.format.units).to.equal('in')
 
-      expect(function () {
+      expect(function() {
         p = plotter({units: 'foo'})
       }).to.throw(/units/)
     })
 
-    it('should allow user to set backupUnits', function () {
+    it('should allow user to set backupUnits', function() {
       p = plotter({backupUnits: 'mm'})
       expect(p.format.backupUnits).to.equal('mm')
       p = plotter({units: 'in'})
       expect(p.format.units).to.equal('in')
 
-      expect(function () {
+      expect(function() {
         p = plotter({backupUnits: 'foo'})
       }).to.throw(/units must be/)
     })
 
-    it('should allow user to set notation', function () {
+    it('should allow user to set notation', function() {
       p = plotter({nota: 'A'})
       expect(p.format.nota).to.equal('A')
       p = plotter({nota: 'I'})
       expect(p.format.nota).to.equal('I')
 
-      expect(function () {
+      expect(function() {
         p = plotter({nota: 'foo'})
       }).to.throw(/notation/)
     })
 
-    it('should allow user to set backup notation', function () {
+    it('should allow user to set backup notation', function() {
       p = plotter({backupNota: 'A'})
       expect(p.format.backupNota).to.equal('A')
       p = plotter({backupNota: 'I'})
       expect(p.format.backupNota).to.equal('I')
 
-      expect(function () {
+      expect(function() {
         p = plotter({backupNota: 'foo'})
       }).to.throw(/notation must be/)
     })
 
-    it('should default backup units and notation to inches and abs', function () {
+    it('should default backup units and notation to inches and abs', function() {
       expect(p.format.backupUnits).to.equal('in')
       expect(p.format.backupNota).to.equal('A')
     })
 
-    it('should not throw with null/undefined options', function () {
+    it('should not throw with null/undefined options', function() {
       var p
-      expect(function () {
+      expect(function() {
         p = plotter({units: null})
       }).to.not.throw()
       expect(p.format.units === null).to.equal(true)
 
-      expect(function () {
+      expect(function() {
         p = plotter({backupUnits: undefined})
       }).to.not.throw()
       expect(p.format.backupUnits).to.equal('in')
 
-      expect(function () {
+      expect(function() {
         p = plotter({nota: undefined})
       }).to.not.throw()
       expect(p.format.nota === null).to.equal(true)
 
-      expect(function () {
+      expect(function() {
         p = plotter({backupNota: null})
       }).to.not.throw()
       expect(p.format.backupNota).to.equal('A')
     })
   })
 
-  describe('plotting options', function () {
-    it('should have an optimize paths option that defaults to falsey', function () {
+  describe('plotting options', function() {
+    it('should have an optimize paths option that defaults to falsey', function() {
       expect(!p._optimizePaths).to.equal(true)
 
       p = plotter({optimizePaths: true})
       expect(p._optimizePaths).to.equal(true)
     })
 
-    it('should have an outline mode option that defaults to falsey', function () {
+    it('should have an outline mode option that defaults to falsey', function() {
       expect(!p._plotAsOutline).to.equal(true)
 
       p = plotter({plotAsOutline: true, units: 'mm'})
       expect(p._plotAsOutline).to.equal(0.00011)
     })
 
-    it('should convert default outline gap fill to inches', function () {
+    it('should convert default outline gap fill to inches', function() {
       expect(!p._plotAsOutline).to.equal(true)
 
       p = plotter({plotAsOutline: true, units: 'in'})
       expect(p._plotAsOutline).to.be.closeTo(0.00011 / 25.4, EPSILON)
     })
 
-    it('should convert given outline gap fill to inches', function () {
+    it('should convert given outline gap fill to inches', function() {
       expect(!p._plotAsOutline).to.equal(true)
 
       p = plotter({plotAsOutline: 0.1, units: 'in'})
       expect(p._plotAsOutline).to.be.closeTo(0.1 / 25.4, EPSILON)
     })
 
-    it('should force optimize paths to true if plot as outline is true', function () {
+    it('should force optimize paths to true if plot as outline is true', function() {
       p = plotter({plotAsOutline: true, optimizePaths: false, units: 'mm'})
       expect(p._plotAsOutline).to.equal(0.00011)
       expect(p._optimizePaths).to.equal(true)
     })
   })
 
-  describe('handling set commands', function () {
-    describe('format', function () {
-      it('should set units', function () {
+  describe('handling set commands', function() {
+    describe('format', function() {
+      it('should set units', function() {
         p.write({type: 'set', prop: 'units', value: 'mm'})
         expect(p.format.units).to.equal('mm')
 
@@ -142,13 +142,13 @@ describe('gerber plotter', function () {
         expect(p.format.units).to.equal('in')
       })
 
-      it('should not redefine units', function () {
+      it('should not redefine units', function() {
         p = plotter({units: 'in'})
         p.write({type: 'set', prop: 'units', value: 'mm'})
         expect(p.format.units).to.equal('in')
       })
 
-      it('should set the notation', function () {
+      it('should set the notation', function() {
         p.write({type: 'set', prop: 'nota', value: 'A'})
         expect(p.format.nota).to.equal('A')
 
@@ -157,34 +157,34 @@ describe('gerber plotter', function () {
         expect(p.format.nota).to.equal('I')
       })
 
-      it('should not redefine notation', function () {
+      it('should not redefine notation', function() {
         p = plotter({nota: 'A'})
         p.write({type: 'set', prop: 'nota', value: 'I'})
         expect(p.format.nota).to.equal('A')
       })
 
-      it('should set the backup units', function () {
+      it('should set the backup units', function() {
         p.write({type: 'set', prop: 'backupUnits', value: 'mm'})
         expect(p.format.backupUnits).to.equal('mm')
         p.write({type: 'set', prop: 'backupUnits', value: 'in'})
         expect(p.format.backupUnits).to.equal('in')
       })
 
-      it('should not redefine the backupUnits set by user', function () {
+      it('should not redefine the backupUnits set by user', function() {
         p = plotter({backupUnits: 'in'})
         p.write({type: 'set', prop: 'backupUnits', value: 'mm'})
         expect(p.format.backupUnits).to.equal('in')
       })
 
-      it('should not redefine the backupNotation set by user', function () {
+      it('should not redefine the backupNotation set by user', function() {
         p = plotter({backupNota: 'A'})
         p.write({type: 'set', prop: 'backupNota', value: 'I'})
         expect(p.format.backupNota).to.equal('A')
       })
     })
 
-    describe('plotter state', function () {
-      it('should change the tool', function () {
+    describe('plotter state', function() {
+      it('should change the tool', function() {
         var tool = {}
         p._tools['10'] = tool
 
@@ -192,8 +192,8 @@ describe('gerber plotter', function () {
         expect(p._tool).to.equal(tool)
       })
 
-      it('should warn if the tool does not exist', function (done) {
-        p.once('warning', function (w) {
+      it('should warn if the tool does not exist', function(done) {
+        p.once('warning', function(w) {
           expect(w.line).to.equal(10)
           expect(w.message).to.match(/tool 10/)
           expect(p._tool === null).to.equal(true)
@@ -203,15 +203,15 @@ describe('gerber plotter', function () {
         p.write({type: 'set', line: 10, prop: 'tool', value: '10'})
       })
 
-      it('should set the region mode', function () {
+      it('should set the region mode', function() {
         p.write({type: 'set', line: 10, prop: 'region', value: true})
         expect(p._region).to.equal(true)
         p.write({type: 'set', line: 10, prop: 'region', value: false})
         expect(p._region).to.equal(false)
       })
 
-      it('should warn and ignore tool changes if region mode is on', function (done) {
-        p.once('warning', function (w) {
+      it('should warn and ignore tool changes if region mode is on', function(done) {
+        p.once('warning', function(w) {
           expect(w.line).to.equal(11)
           expect(w.message).to.match(/region/)
           expect(p._tool === null).to.equal(true)
@@ -223,7 +223,7 @@ describe('gerber plotter', function () {
         p.write({type: 'set', line: 11, prop: 'tool', value: '10'})
       })
 
-      it('should set the interpolation mode', function () {
+      it('should set the interpolation mode', function() {
         p.write({type: 'set', prop: 'mode', value: 'i'})
         expect(p._mode).to.equal('i')
         p.write({type: 'set', prop: 'mode', value: 'cw'})
@@ -232,7 +232,7 @@ describe('gerber plotter', function () {
         expect(p._mode).to.equal('ccw')
       })
 
-      it('should set the arc quadrant mode', function () {
+      it('should set the arc quadrant mode', function() {
         p.write({type: 'set', prop: 'quad', value: 's'})
         expect(p._quad).to.equal('s')
         p.write({type: 'set', prop: 'quad', value: 'm'})
@@ -241,14 +241,14 @@ describe('gerber plotter', function () {
     })
   })
 
-  describe('handling done command', function () {
-    it('should set the done flag', function () {
+  describe('handling done command', function() {
+    it('should set the done flag', function() {
       p.write({type: 'done'})
       expect(p._done).to.equal(true)
     })
 
-    it('should warn if other commands come in after a done', function (done) {
-      p.once('warning', function (w) {
+    it('should warn if other commands come in after a done', function(done) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/done/)
         done()
       })
@@ -258,8 +258,8 @@ describe('gerber plotter', function () {
     })
   })
 
-  describe('handling new tool commands', function () {
-    it('should set current tool to newly defined tool', function () {
+  describe('handling new tool commands', function() {
+    it('should set current tool to newly defined tool', function() {
       var circle = {shape: 'circle', params: [4], hole: []}
       p.write({type: 'tool', code: '10', tool: circle})
       expect(p._tools['10']).to.equal(p._tool)
@@ -267,7 +267,7 @@ describe('gerber plotter', function () {
       expect(p._tools['15']).to.equal(p._tool)
     })
 
-    it('should set trace width for circle and rectangle tools', function () {
+    it('should set trace width for circle and rectangle tools', function() {
       var circle = {shape: 'circle', params: [4], hole: []}
       var rect = {shape: 'rect', params: [2, 3], hole: []}
 
@@ -278,11 +278,11 @@ describe('gerber plotter', function () {
       expect(p._tool.trace).to.eql([2, 3])
     })
 
-    it('should warn and ignore if the tool has already been set', function (done) {
+    it('should warn and ignore if the tool has already been set', function(done) {
       var circle = {shape: 'circle', params: [4], hole: []}
       var rect = {shape: 'rect', params: [2, 3], hole: []}
 
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/already defined/)
         expect(w.line).to.equal(9)
         expect(p._tool.trace).to.eql([4])
@@ -293,7 +293,7 @@ describe('gerber plotter', function () {
       p.write({type: 'tool', code: '10', tool: rect, line: 9})
     })
 
-    it('should not set trace for untraceable tools', function () {
+    it('should not set trace for untraceable tools', function() {
       var circle = {shape: 'circle', params: [4], hole: [1, 1]}
       var rect = {shape: 'rect', params: [2, 3], hole: [1]}
       var obround = {shape: 'obround', params: [2, 3], hole: []}
@@ -311,8 +311,8 @@ describe('gerber plotter', function () {
       expect(p._tool.trace).to.eql([])
     })
 
-    describe('standard tool pad shapes', function () {
-      it('should create pad shapes for standard circles', function () {
+    describe('standard tool pad shapes', function() {
+      it('should create pad shapes for standard circles', function() {
         var circle0 = {shape: 'circle', params: [1], hole: []}
         var circle1 = {shape: 'circle', params: [2], hole: [1]}
         var circle2 = {shape: 'circle', params: [3], hole: [1, 1]}
@@ -324,68 +324,68 @@ describe('gerber plotter', function () {
         expect(p._tool.pad).to.eql([
           {type: 'circle', cx: 0, cy: 0, r: 1},
           {type: 'layer', polarity: 'clear', box: [-1, -1, 1, 1]},
-          {type: 'circle', cx: 0, cy: 0, r: 0.5}
+          {type: 'circle', cx: 0, cy: 0, r: 0.5},
         ])
 
         p.write({type: 'tool', code: '12', tool: circle2})
         expect(p._tool.pad).to.eql([
           {type: 'circle', cx: 0, cy: 0, r: 1.5},
           {type: 'layer', polarity: 'clear', box: [-1.5, -1.5, 1.5, 1.5]},
-          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
+          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1},
         ])
       })
 
-      it('should create pad shapes for standard rectangles', function () {
+      it('should create pad shapes for standard rectangles', function() {
         var rect0 = {shape: 'rect', params: [1, 2], hole: []}
         var rect1 = {shape: 'rect', params: [3, 4], hole: [1]}
         var rect2 = {shape: 'rect', params: [5, 6], hole: [1, 1]}
 
         p.write({type: 'tool', code: '10', tool: rect0})
         expect(p._tool.pad).to.eql([
-          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 2}
+          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 2},
         ])
 
         p.write({type: 'tool', code: '11', tool: rect1})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 3, height: 4},
           {type: 'layer', polarity: 'clear', box: [-1.5, -2, 1.5, 2]},
-          {type: 'circle', cx: 0, cy: 0, r: 0.5}
+          {type: 'circle', cx: 0, cy: 0, r: 0.5},
         ])
 
         p.write({type: 'tool', code: '12', tool: rect2})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 0, width: 5, height: 6},
           {type: 'layer', polarity: 'clear', box: [-2.5, -3, 2.5, 3]},
-          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
+          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1},
         ])
       })
 
-      it('should create pad shapes for standard obrounds', function () {
+      it('should create pad shapes for standard obrounds', function() {
         var obround0 = {shape: 'obround', params: [1, 2], hole: []}
         var obround1 = {shape: 'obround', params: [4, 3], hole: [1]}
         var obround2 = {shape: 'obround', params: [5, 6], hole: [1, 1]}
 
         p.write({type: 'tool', code: '10', tool: obround0})
         expect(p._tool.pad).to.eql([
-          {type: 'rect', cx: 0, cy: 0, r: 0.5, width: 1, height: 2}
+          {type: 'rect', cx: 0, cy: 0, r: 0.5, width: 1, height: 2},
         ])
 
         p.write({type: 'tool', code: '11', tool: obround1})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 1.5, width: 4, height: 3},
           {type: 'layer', polarity: 'clear', box: [-2, -1.5, 2, 1.5]},
-          {type: 'circle', cx: 0, cy: 0, r: 0.5}
+          {type: 'circle', cx: 0, cy: 0, r: 0.5},
         ])
 
         p.write({type: 'tool', code: '12', tool: obround2})
         expect(p._tool.pad).to.eql([
           {type: 'rect', cx: 0, cy: 0, r: 2.5, width: 5, height: 6},
           {type: 'layer', polarity: 'clear', box: [-2.5, -3, 2.5, 3]},
-          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
+          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1},
         ])
       })
 
-      it('should create pad shapes for standard polygons', function () {
+      it('should create pad shapes for standard polygons', function() {
         var poly0 = {shape: 'poly', params: [2, 3, 0], hole: []}
         var poly1 = {shape: 'poly', params: [2, 6, 45], hole: [1]}
         var poly2 = {shape: 'poly', params: [2, 12, 140], hole: [1, 1]}
@@ -394,8 +394,8 @@ describe('gerber plotter', function () {
         expect(p._tool.pad).to.eql([
           {
             type: 'poly',
-            points: [[1, 0], [-0.5, 0.8660254], [-0.5, -0.8660254]]
-          }
+            points: [[1, 0], [-0.5, 0.8660254], [-0.5, -0.8660254]],
+          },
         ])
 
         p.write({type: 'tool', code: '11', tool: poly1})
@@ -411,11 +411,11 @@ describe('gerber plotter', function () {
           [-0.96592583, 0.25881905],
           [-0.70710678, -0.70710678],
           [0.25881905, -0.96592583],
-          [0.96592583, -0.25881905]
+          [0.96592583, -0.25881905],
         ])
         expect(p._tool.pad.slice(1)).to.eql([
           {type: 'layer', polarity: 'clear', box: box},
-          {type: 'circle', cx: 0, cy: 0, r: 0.5}
+          {type: 'circle', cx: 0, cy: 0, r: 0.5},
         ])
 
         p.write({type: 'tool', code: '12', tool: poly2})
@@ -437,17 +437,17 @@ describe('gerber plotter', function () {
           [0.93969262, 0.34202014],
           [0.64278761, 0.76604444],
           [0.17364818, 0.98480775],
-          [-0.34202014, 0.93969262]
+          [-0.34202014, 0.93969262],
         ])
         expect(p._tool.pad.slice(1)).to.eql([
           {type: 'layer', polarity: 'clear', box: box},
-          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1}
+          {type: 'rect', cx: 0, cy: 0, r: 0, width: 1, height: 1},
         ])
       })
     })
 
-    describe('standard tool bounding boxes', function () {
-      it('should calculate a bounding box for a circle', function () {
+    describe('standard tool bounding boxes', function() {
+      it('should calculate a bounding box for a circle', function() {
         var circle0 = {shape: 'circle', params: [1], hole: []}
         var circle1 = {shape: 'circle', params: [7], hole: [1]}
         var circle2 = {shape: 'circle', params: [4], hole: [1, 1]}
@@ -460,7 +460,7 @@ describe('gerber plotter', function () {
         expect(p._tool.box).to.eql([-2, -2, 2, 2])
       })
 
-      it('should calculate a bounding box for a rects and obrounds', function () {
+      it('should calculate a bounding box for a rects and obrounds', function() {
         var rect0 = {shape: 'rect', params: [1, 2], hole: []}
         var rect1 = {shape: 'rect', params: [7, 4], hole: [1]}
         var obround0 = {shape: 'obround', params: [9, 8], hole: [1, 1]}
@@ -476,13 +476,13 @@ describe('gerber plotter', function () {
         expect(p._tool.box).to.eql([-2, -0.5, 2, 0.5])
       })
 
-      it('should calculate a bounding box for a standard polygon', function () {
+      it('should calculate a bounding box for a standard polygon', function() {
         var poly0 = {shape: 'poly', params: [5, 4, 0], hole: []}
         var poly1 = {shape: 'poly', params: [6, 8, 0], hole: [1]}
         var poly2 = {
           shape: 'poly',
           params: [4 * Math.sqrt(2), 4, 45],
-          hole: [1, 1]
+          hole: [1, 1],
         }
 
         p.write({type: 'tool', code: '10', tool: poly0})
@@ -494,18 +494,18 @@ describe('gerber plotter', function () {
       })
     })
 
-    describe('macro tool pads', function () {
-      describe('primitives without rotation', function () {
-        it('should ignore comment primitives', function () {
+    describe('macro tool pads', function() {
+      describe('primitives without rotation', function() {
+        it('should ignore comment primitives', function() {
           var macro = {
             type: 'macro',
             name: 'EMPTY',
-            blocks: [{type: 'comment'}]
+            blocks: [{type: 'comment'}],
           }
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'EMPTY', params: [], hole: []}
+            tool: {shape: 'EMPTY', params: [], hole: []},
           }
 
           p.write(macro)
@@ -514,13 +514,13 @@ describe('gerber plotter', function () {
           expect(p._tool.box).to.eql([Infinity, Infinity, -Infinity, -Infinity])
         })
 
-        it('should be able to handle shape and box for circle primitives', function () {
+        it('should be able to handle shape and box for circle primitives', function() {
           var blocks = [{type: 'circle', exp: 1, dia: 4, cx: 3, cy: 4, rot: 0}]
           var macro = {type: 'macro', name: 'CIRC', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'CIRC', params: [], hole: []}
+            tool: {shape: 'CIRC', params: [], hole: []},
           }
 
           p.write(macro)
@@ -529,7 +529,7 @@ describe('gerber plotter', function () {
           expect(p._tool.box).to.eql([1, 2, 5, 6])
         })
 
-        it('should be able to handle shape and box for vect primitives', function () {
+        it('should be able to handle shape and box for vect primitives', function() {
           var blocks = [
             {
               type: 'vect',
@@ -539,7 +539,7 @@ describe('gerber plotter', function () {
               y1: 0,
               x2: 5,
               y2: 0,
-              rot: 0
+              rot: 0,
             },
             {
               type: 'vect',
@@ -549,14 +549,14 @@ describe('gerber plotter', function () {
               y1: 0,
               x2: 0,
               y2: 5,
-              rot: 0
-            }
+              rot: 0,
+            },
           ]
           var macro = {type: 'macro', name: 'VECT', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'VECT', params: [], hole: []}
+            tool: {shape: 'VECT', params: [], hole: []},
           }
 
           p.write(macro)
@@ -564,78 +564,78 @@ describe('gerber plotter', function () {
 
           expect(p._tool.pad).to.eql([
             {type: 'poly', points: [[0, -1], [5, -1], [5, 1], [0, 1]]},
-            {type: 'poly', points: [[0.5, 0], [0.5, 5], [-0.5, 5], [-0.5, 0]]}
+            {type: 'poly', points: [[0.5, 0], [0.5, 5], [-0.5, 5], [-0.5, 0]]},
           ])
 
           expect(p._tool.box).to.eql([-0.5, -1, 5, 5])
         })
 
-        it('should be able to handle rectangle primitives', function () {
+        it('should be able to handle rectangle primitives', function() {
           var blocks = [
-            {type: 'rect', exp: 1, width: 4, height: 2, cx: 3, cy: 4, rot: 0}
+            {type: 'rect', exp: 1, width: 4, height: 2, cx: 3, cy: 4, rot: 0},
           ]
           var macro = {type: 'macro', name: 'RECT', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'RECT', params: [], hole: []}
+            tool: {shape: 'RECT', params: [], hole: []},
           }
 
           p.write(macro)
           p.write(tool)
           expect(p._tool.pad).to.eql([
-            {type: 'rect', cx: 3, cy: 4, width: 4, height: 2, r: 0}
+            {type: 'rect', cx: 3, cy: 4, width: 4, height: 2, r: 0},
           ])
           expect(p._tool.box).to.eql([1, 3, 5, 5])
         })
 
-        it('should be able to handle lower-left rects', function () {
+        it('should be able to handle lower-left rects', function() {
           var blocks = [
-            {type: 'rectLL', exp: 1, width: 4, height: 2, x: 1, y: 3, rot: 0}
+            {type: 'rectLL', exp: 1, width: 4, height: 2, x: 1, y: 3, rot: 0},
           ]
           var macro = {type: 'macro', name: 'LRECT', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'LRECT', params: [], hole: []}
+            tool: {shape: 'LRECT', params: [], hole: []},
           }
 
           p.write(macro)
           p.write(tool)
           expect(p._tool.pad).to.eql([
-            {type: 'rect', cx: 3, cy: 4, width: 4, height: 2, r: 0}
+            {type: 'rect', cx: 3, cy: 4, width: 4, height: 2, r: 0},
           ])
           expect(p._tool.box).to.eql([1, 3, 5, 5])
         })
 
-        it('should be able to handle an outline primitive', function () {
+        it('should be able to handle an outline primitive', function() {
           var blocks = [
-            {type: 'outline', exp: 1, points: [0, 0, 1, 0, 1, 1, 0, 0], rot: 0}
+            {type: 'outline', exp: 1, points: [0, 0, 1, 0, 1, 1, 0, 0], rot: 0},
           ]
           var macro = {type: 'macro', name: 'OPOLY', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'OPOLY', params: [], hole: []}
+            tool: {shape: 'OPOLY', params: [], hole: []},
           }
 
           p.write(macro)
           p.write(tool)
           expect(p._tool.pad).to.eql([
-            {type: 'poly', points: [[0, 0], [1, 0], [1, 1]]}
+            {type: 'poly', points: [[0, 0], [1, 0], [1, 1]]},
           ])
           expect(p._tool.box).to.eql([0, 0, 1, 1])
         })
 
-        it('should handle a regular polygon primitive', function () {
+        it('should handle a regular polygon primitive', function() {
           var blocks = [
-            {type: 'poly', exp: 1, vertices: 4, cx: 3, cy: 2, dia: 2, rot: 0}
+            {type: 'poly', exp: 1, vertices: 4, cx: 3, cy: 2, dia: 2, rot: 0},
           ]
           var macro = {type: 'macro', name: 'POLY', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'POLY', params: [], hole: []}
+            tool: {shape: 'POLY', params: [], hole: []},
           }
 
           p.write(macro)
@@ -643,13 +643,13 @@ describe('gerber plotter', function () {
           expect(p._tool.pad).to.eql([
             {
               type: 'poly',
-              points: [[4, 2], [3, 3], [2, 2], [3, 1]]
-            }
+              points: [[4, 2], [3, 3], [2, 2], [3, 1]],
+            },
           ])
           expect(p._tool.box).to.eql([2, 1, 4, 3])
         })
 
-        it('should handle moiré primitives with only rings', function () {
+        it('should handle moiré primitives with only rings', function() {
           var blocks = [
             {
               type: 'moire',
@@ -662,14 +662,14 @@ describe('gerber plotter', function () {
               maxRings: 2,
               crossThx: 0.1,
               crossLen: 5,
-              rot: 0
-            }
+              rot: 0,
+            },
           ]
           var macro = {type: 'macro', name: 'TARG', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'TARG', params: [], hole: []}
+            tool: {shape: 'TARG', params: [], hole: []},
           }
 
           p.write(macro)
@@ -678,12 +678,12 @@ describe('gerber plotter', function () {
             {type: 'ring', cx: 2, cy: 3, r: 1.8, width: 0.4},
             {type: 'ring', cx: 2, cy: 3, r: 1.2, width: 0.4},
             {type: 'rect', cx: 2, cy: 3, width: 5, height: 0.1, r: 0},
-            {type: 'rect', cx: 2, cy: 3, width: 0.1, height: 5, r: 0}
+            {type: 'rect', cx: 2, cy: 3, width: 0.1, height: 5, r: 0},
           ])
           expect(p._tool.box).to.eql([-0.5, 0.5, 4.5, 5.5])
         })
 
-        it('should handle moirés with circle centers', function () {
+        it('should handle moirés with circle centers', function() {
           var blocks = [
             {
               type: 'moire',
@@ -696,14 +696,14 @@ describe('gerber plotter', function () {
               maxRings: 2,
               crossThx: 0.2,
               crossLen: 2.5,
-              rot: 0
-            }
+              rot: 0,
+            },
           ]
           var macro = {type: 'macro', name: 'TARG', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'TARG', params: [], hole: []}
+            tool: {shape: 'TARG', params: [], hole: []},
           }
 
           p.write(macro)
@@ -712,12 +712,12 @@ describe('gerber plotter', function () {
             {type: 'ring', cx: 5, cy: 5, r: 1.15, width: 0.5},
             {type: 'circle', cx: 5, cy: 5, r: 0.4},
             {type: 'rect', cx: 5, cy: 5, width: 2.5, height: 0.2, r: 0},
-            {type: 'rect', cx: 5, cy: 5, width: 0.2, height: 2.5, r: 0}
+            {type: 'rect', cx: 5, cy: 5, width: 0.2, height: 2.5, r: 0},
           ])
           expect(p._tool.box).to.eql([3.6, 3.6, 6.4, 6.4])
         })
 
-        it('should handle thermals', function () {
+        it('should handle thermals', function() {
           var blocks = [
             {
               type: 'thermal',
@@ -727,14 +727,14 @@ describe('gerber plotter', function () {
               outerDia: 7,
               innerDia: 5,
               gap: 1,
-              rot: 0
-            }
+              rot: 0,
+            },
           ]
           var macro = {type: 'macro', name: 'THRM', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'THRM', params: [], hole: []}
+            tool: {shape: 'THRM', params: [], hole: []},
           }
 
           p.write(macro)
@@ -746,23 +746,23 @@ describe('gerber plotter', function () {
                 {type: 'rect', cx: 3, cy: 3, width: 3, height: 3, r: 0},
                 {type: 'rect', cx: -1, cy: 3, width: 3, height: 3, r: 0},
                 {type: 'rect', cx: -1, cy: -1, width: 3, height: 3, r: 0},
-                {type: 'rect', cx: 3, cy: -1, width: 3, height: 3, r: 0}
+                {type: 'rect', cx: 3, cy: -1, width: 3, height: 3, r: 0},
               ],
-              clip: {type: 'ring', cx: 1, cy: 1, r: 3, width: 1}
-            }
+              clip: {type: 'ring', cx: 1, cy: 1, r: 3, width: 1},
+            },
           ])
           expect(p._tool.box).to.eql([-2.5, -2.5, 4.5, 4.5])
         })
       })
 
-      describe('rotated primitives', function () {
-        it('should handle rotated circles', function () {
+      describe('rotated primitives', function() {
+        it('should handle rotated circles', function() {
           var blocks = [{type: 'circle', exp: 1, dia: 4, cx: 0, cy: 4, rot: 90}]
           var macro = {type: 'macro', name: 'RCIRC', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'RCIRC', params: [], hole: []}
+            tool: {shape: 'RCIRC', params: [], hole: []},
           }
 
           p.write(macro)
@@ -771,7 +771,7 @@ describe('gerber plotter', function () {
           expect(p._tool.box).to.eql([-6, -2, -2, 2])
         })
 
-        it('should handle rotated vects', function () {
+        it('should handle rotated vects', function() {
           var blocks = [
             {
               type: 'vect',
@@ -781,14 +781,14 @@ describe('gerber plotter', function () {
               y1: 1,
               x2: 5,
               y2: 5,
-              rot: 45
-            }
+              rot: 45,
+            },
           ]
           var macro = {type: 'macro', name: 'RVECT', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'RVECT', params: [], hole: []}
+            tool: {shape: 'RVECT', params: [], hole: []},
           }
 
           p.write(macro)
@@ -801,22 +801,22 @@ describe('gerber plotter', function () {
                 [0.5, 1.41421356],
                 [0.5, 7.07106781],
                 [-0.5, 7.07106781],
-                [-0.5, 1.41421356]
-              ]
-            }
+                [-0.5, 1.41421356],
+              ],
+            },
           ])
           expect(p._tool.box).to.eql([-0.5, 1.41421356, 0.5, 7.07106781])
         })
 
-        it('should handle rotated rects', function () {
+        it('should handle rotated rects', function() {
           var blocks = [
-            {type: 'rect', exp: 1, width: 4, height: 2, cx: 3, cy: 4, rot: -30}
+            {type: 'rect', exp: 1, width: 4, height: 2, cx: 3, cy: 4, rot: -30},
           ]
           var macro = {type: 'macro', name: 'RRECT', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'RRECT', params: [], hole: []}
+            tool: {shape: 'RRECT', params: [], hole: []},
           }
 
           p.write(macro)
@@ -829,27 +829,27 @@ describe('gerber plotter', function () {
                 [2.3660254, 2.09807622],
                 [5.83012702, 0.09807622],
                 [6.83012702, 1.83012702],
-                [3.3660254, 3.83012702]
-              ]
-            }
+                [3.3660254, 3.83012702],
+              ],
+            },
           ])
           expect(p._tool.box).to.eql([
             2.3660254,
             0.09807622,
             6.83012702,
-            3.83012702
+            3.83012702,
           ])
         })
 
-        it('should handle rotated lower-left rects', function () {
+        it('should handle rotated lower-left rects', function() {
           var blocks = [
-            {type: 'rectLL', exp: 1, width: 4, height: 2, x: 1, y: 3, rot: -30}
+            {type: 'rectLL', exp: 1, width: 4, height: 2, x: 1, y: 3, rot: -30},
           ]
           var macro = {type: 'macro', name: 'LRECT', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'LRECT', params: [], hole: []}
+            tool: {shape: 'LRECT', params: [], hole: []},
           }
 
           p.write(macro)
@@ -862,32 +862,32 @@ describe('gerber plotter', function () {
                 [2.3660254, 2.09807622],
                 [5.83012702, 0.09807622],
                 [6.83012702, 1.83012702],
-                [3.3660254, 3.83012702]
-              ]
-            }
+                [3.3660254, 3.83012702],
+              ],
+            },
           ])
           expect(p._tool.box).to.eql([
             2.3660254,
             0.09807622,
             6.83012702,
-            3.83012702
+            3.83012702,
           ])
         })
 
-        it('should handle rotated outline polygons', function () {
+        it('should handle rotated outline polygons', function() {
           var blocks = [
             {
               type: 'outline',
               exp: 1,
               points: [0, 0, 1, 0, 1, 1, 0, 0],
-              rot: 150
-            }
+              rot: 150,
+            },
           ]
           var macro = {type: 'macro', name: 'LRECT', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'LRECT', params: [], hole: []}
+            tool: {shape: 'LRECT', params: [], hole: []},
           }
 
           p.write(macro)
@@ -895,13 +895,13 @@ describe('gerber plotter', function () {
           expect(p._tool.pad).to.eql([
             {
               type: 'poly',
-              points: [[0, 0], [-0.8660254, 0.5], [-1.3660254, -0.3660254]]
-            }
+              points: [[0, 0], [-0.8660254, 0.5], [-1.3660254, -0.3660254]],
+            },
           ])
           expect(p._tool.box).to.eql([-1.3660254, -0.3660254, 0, 0.5])
         })
 
-        it('should handle rotated regular polygons', function () {
+        it('should handle rotated regular polygons', function() {
           var dia = 2 * Math.sqrt(2)
           var blocks = [
             {
@@ -911,14 +911,14 @@ describe('gerber plotter', function () {
               cx: 0,
               cy: 0,
               dia: dia,
-              rot: 45
-            }
+              rot: 45,
+            },
           ]
           var macro = {type: 'macro', name: 'POLY', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'POLY', params: [], hole: []}
+            tool: {shape: 'POLY', params: [], hole: []},
           }
 
           p.write(macro)
@@ -926,13 +926,13 @@ describe('gerber plotter', function () {
           expect(p._tool.pad).to.eql([
             {
               type: 'poly',
-              points: [[1, 1], [-1, 1], [-1, -1], [1, -1]]
-            }
+              points: [[1, 1], [-1, 1], [-1, -1], [1, -1]],
+            },
           ])
           expect(p._tool.box).to.eql([-1, -1, 1, 1])
         })
 
-        it('should handle rotated moires', function () {
+        it('should handle rotated moires', function() {
           var blocks = [
             {
               type: 'moire',
@@ -945,14 +945,14 @@ describe('gerber plotter', function () {
               maxRings: 2,
               crossThx: 0.1,
               crossLen: 5,
-              rot: -150
-            }
+              rot: -150,
+            },
           ]
           var macro = {type: 'macro', name: 'TARG', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'TARG', params: [], hole: []}
+            tool: {shape: 'TARG', params: [], hole: []},
           }
 
           p.write(macro)
@@ -966,8 +966,8 @@ describe('gerber plotter', function () {
                 [2.19006351, 1.20669873],
                 [-2.14006351, -1.29330127],
                 [-2.19006351, -1.20669873],
-                [2.14006351, 1.29330127]
-              ]
+                [2.14006351, 1.29330127],
+              ],
             },
             {
               type: 'poly',
@@ -975,19 +975,19 @@ describe('gerber plotter', function () {
                 [1.29330127, -2.14006351],
                 [1.20669873, -2.19006351],
                 [-1.29330127, 2.14006351],
-                [-1.20669873, 2.19006351]
-              ]
-            }
+                [-1.20669873, 2.19006351],
+              ],
+            },
           ])
           expect(p._tool.box).to.eql([
             -2.19006351,
             -2.19006351,
             2.19006351,
-            2.19006351
+            2.19006351,
           ])
         })
 
-        it('should handle rotated thermals', function () {
+        it('should handle rotated thermals', function() {
           var blocks = [
             {
               type: 'thermal',
@@ -997,14 +997,14 @@ describe('gerber plotter', function () {
               outerDia: 4,
               innerDia: 3,
               gap: 0.2,
-              rot: 45
-            }
+              rot: 45,
+            },
           ]
           var macro = {type: 'macro', name: 'THRM', blocks: blocks}
           var tool = {
             type: 'tool',
             code: '10',
-            tool: {shape: 'THRM', params: [], hole: []}
+            tool: {shape: 'THRM', params: [], hole: []},
           }
 
           p.write(macro)
@@ -1019,8 +1019,8 @@ describe('gerber plotter', function () {
                     [0, 0.14142136],
                     [1.34350288, 1.48492424],
                     [0, 2.82842712],
-                    [-1.34350288, 1.48492424]
-                  ]
+                    [-1.34350288, 1.48492424],
+                  ],
                 },
                 {
                   type: 'poly',
@@ -1028,8 +1028,8 @@ describe('gerber plotter', function () {
                     [-1.48492424, -1.34350288],
                     [-0.14142136, 0],
                     [-1.48492424, 1.34350288],
-                    [-2.82842712, 0]
-                  ]
+                    [-2.82842712, 0],
+                  ],
                 },
                 {
                   type: 'poly',
@@ -1037,8 +1037,8 @@ describe('gerber plotter', function () {
                     [0, -2.82842712],
                     [1.34350288, -1.48492424],
                     [0, -0.14142136],
-                    [-1.34350288, -1.48492424]
-                  ]
+                    [-1.34350288, -1.48492424],
+                  ],
                 },
                 {
                   type: 'poly',
@@ -1046,42 +1046,42 @@ describe('gerber plotter', function () {
                     [1.48492424, -1.34350288],
                     [2.82842712, 0],
                     [1.48492424, 1.34350288],
-                    [0.14142136, 0]
-                  ]
-                }
+                    [0.14142136, 0],
+                  ],
+                },
               ],
-              clip: {type: 'ring', cx: 0, cy: 0, r: 1.75, width: 0.5}
-            }
+              clip: {type: 'ring', cx: 0, cy: 0, r: 1.75, width: 0.5},
+            },
           ])
           expect(p._tool.box).to.eql([-2, -2, 2, 2])
         })
       })
 
-      it('should handle modifiers and functional args', function () {
+      it('should handle modifiers and functional args', function() {
         var blocks = [
           {
             type: 'circle',
             exp: 1,
-            dia: function (mods) {
+            dia: function(mods) {
               return mods.$1
             },
-            cx: function (mods) {
+            cx: function(mods) {
               return mods.$2
             },
-            cy: function (mods) {
+            cy: function(mods) {
               return mods.$3
             },
-            rot: function (mods) {
+            rot: function(mods) {
               return mods.$4
-            }
-          }
+            },
+          },
         ]
         var mods = [4, 3, 2, 0]
         var macro = {type: 'macro', name: 'CIRC', blocks: blocks}
         var tool = {
           type: 'tool',
           code: '10',
-          tool: {shape: 'CIRC', params: mods, hole: []}
+          tool: {shape: 'CIRC', params: mods, hole: []},
         }
 
         p.write(macro)
@@ -1089,35 +1089,35 @@ describe('gerber plotter', function () {
         expect(p._tool.pad).to.eql([{type: 'circle', cx: 3, cy: 2, r: 2}])
       })
 
-      it('should handle variable sets', function () {
+      it('should handle variable sets', function() {
         var blocks = [
           {
             type: 'variable',
-            set: function (mods) {
+            set: function(mods) {
               return {$1: 4, $2: 3, $3: mods.$2 - 1}
-            }
+            },
           },
           {
             type: 'circle',
             exp: 1,
-            dia: function (mods) {
+            dia: function(mods) {
               return mods.$1
             },
-            cx: function (mods) {
+            cx: function(mods) {
               return mods.$2
             },
-            cy: function (mods) {
+            cy: function(mods) {
               return mods.$3
             },
-            rot: 0
-          }
+            rot: 0,
+          },
         ]
         var mods = [4, 3]
         var macro = {type: 'macro', name: 'CIRC', blocks: blocks}
         var tool = {
           type: 'tool',
           code: '10',
-          tool: {shape: 'CIRC', params: mods, hole: []}
+          tool: {shape: 'CIRC', params: mods, hole: []},
         }
 
         p.write(macro)
@@ -1125,18 +1125,18 @@ describe('gerber plotter', function () {
         expect(p._tool.pad).to.eql([{type: 'circle', cx: 3, cy: 2, r: 2}])
       })
 
-      it('should handle multiple primitives and exposure', function () {
+      it('should handle multiple primitives and exposure', function() {
         var blocks = [
           {type: 'circle', exp: 1, dia: 4, cx: -2, cy: 0, rot: 0},
           {type: 'rect', exp: 0, width: 1, height: 1, cx: -1, cy: 0, rot: 0},
           {type: 'rect', exp: 0, width: 1, height: 1, cx: 1, cy: 0, rot: 0},
-          {type: 'circle', exp: 1, dia: 4, cx: 2, cy: 0, rot: 0}
+          {type: 'circle', exp: 1, dia: 4, cx: 2, cy: 0, rot: 0},
         ]
         var macro = {type: 'macro', name: 'MAC', blocks: blocks}
         var tool = {
           type: 'tool',
           code: '10',
-          tool: {shape: 'MAC', params: [], hole: []}
+          tool: {shape: 'MAC', params: [], hole: []},
         }
 
         p.write(macro)
@@ -1147,15 +1147,15 @@ describe('gerber plotter', function () {
           {type: 'rect', width: 1, height: 1, cx: -1, cy: 0, r: 0},
           {type: 'rect', width: 1, height: 1, cx: 1, cy: 0, r: 0},
           {type: 'layer', polarity: 'dark', box: [-4, -2, 0, 2]},
-          {type: 'circle', cx: 2, cy: 0, r: 2}
+          {type: 'circle', cx: 2, cy: 0, r: 2},
         ])
         expect(p._tool.box).to.eql([-4, -2, 4, 2])
       })
     })
   })
 
-  describe('handling operation commands', function () {
-    beforeEach(function () {
+  describe('handling operation commands', function() {
+    beforeEach(function() {
       var tool = {shape: 'circle', params: [2], hole: []}
       p.write({type: 'set', prop: 'epsilon', value: 0.00000001})
       p.write({type: 'set', prop: 'units', value: 'in'})
@@ -1164,7 +1164,7 @@ describe('gerber plotter', function () {
       p.write({type: 'tool', code: '10', tool: tool})
     })
 
-    it('should move the plotter', function () {
+    it('should move the plotter', function() {
       p.write({type: 'op', op: 'int', coord: {x: 4, y: -3}})
       expect(p._pos).to.eql([4, -3])
       p.write({type: 'op', op: 'move', coord: {y: 0}})
@@ -1173,7 +1173,7 @@ describe('gerber plotter', function () {
       expect(p._pos).to.eql([-7, 0])
     })
 
-    it('should move the plotter with incremental notation', function () {
+    it('should move the plotter with incremental notation', function() {
       p.nota = 'I'
       p.write({type: 'op', op: 'int', coord: {x: 4, y: -3, i: 1, j: 4}})
       expect(p._pos).to.eql([4, -3])
@@ -1183,24 +1183,24 @@ describe('gerber plotter', function () {
       expect(p._pos).to.eql([-3, -2])
     })
 
-    describe('flashing pads', function () {
-      it('should emit a shape if first flash for tool', function (done) {
-        p.once('readable', function () {
+    describe('flashing pads', function() {
+      it('should emit a shape if first flash for tool', function(done) {
+        p.once('readable', function() {
           var result = p.read()
           expect(result).to.eql({
             type: 'shape',
             tool: '10',
-            shape: p._tool.pad
+            shape: p._tool.pad,
           })
           done()
         })
         p.write({type: 'op', op: 'flash', coord: {x: 1, y: 1}})
       })
 
-      it('should emit pad objects after the shape object', function (done) {
-        p.once('data', function (result) {
+      it('should emit pad objects after the shape object', function(done) {
+        p.once('data', function(result) {
           expect(result.type).to.equal('shape')
-          p.once('data', function (result) {
+          p.once('data', function(result) {
             expect(result).to.eql({type: 'pad', tool: '10', x: 1, y: 1})
             done()
           })
@@ -1208,10 +1208,10 @@ describe('gerber plotter', function () {
         p.write({type: 'op', op: 'flash', coord: {x: 1, y: 1}})
       })
 
-      it('should not emit the pad shape more than once', function (done) {
+      it('should not emit the pad shape more than once', function(done) {
         var results = 0
         var expected = ['shape', 'pad', 'pad']
-        var handleData = function (data) {
+        var handleData = function(data) {
           expect(data.type).to.eql(expected[results])
           if (++results >= expected.length) {
             p.removeListener('data', handleData)
@@ -1224,14 +1224,14 @@ describe('gerber plotter', function () {
         p.write({type: 'op', op: 'flash', coord: {x: 5, y: 5}})
       })
 
-      it('should update the bounding box', function () {
+      it('should update the bounding box', function() {
         p.write({type: 'op', op: 'flash', coord: {x: 1, y: 1}})
         expect(p._box).to.eql([0, 0, 2, 2])
       })
     })
 
-    describe('interpolating to create strokes', function () {
-      it('should create a path graph with linear strokes', function () {
+    describe('interpolating to create strokes', function() {
+      it('should create a path graph with linear strokes', function() {
         p.write({type: 'op', op: 'int', coord: {x: 1, y: 1}})
         p.write({type: 'op', op: 'int', coord: {x: 1, y: 3}})
         p.write({type: 'op', op: 'int', coord: {x: 3, y: 3}})
@@ -1239,11 +1239,11 @@ describe('gerber plotter', function () {
         expect(p._path.traverse()).to.eql([
           {type: 'line', start: [0, 0], end: [1, 1]},
           {type: 'line', start: [1, 1], end: [1, 3]},
-          {type: 'line', start: [1, 3], end: [3, 3]}
+          {type: 'line', start: [1, 3], end: [3, 3]},
         ])
       })
 
-      it('should handle moves in between strokes when optimizing paths', function () {
+      it('should handle moves in between strokes when optimizing paths', function() {
         var tool = {shape: 'circle', params: [2], hole: []}
         p = plotter({optimizePaths: true})
 
@@ -1262,11 +1262,11 @@ describe('gerber plotter', function () {
         expect(p._path.traverse()).to.eql([
           {type: 'line', start: [0, 0], end: [1, 1]},
           {type: 'line', start: [1, 1], end: [1, 3]},
-          {type: 'line', start: [1, 3], end: [3, 3]}
+          {type: 'line', start: [1, 3], end: [3, 3]},
         ])
       })
 
-      it('should handle moves in between strokes when not optimizing paths', function () {
+      it('should handle moves in between strokes when not optimizing paths', function() {
         var tool = {shape: 'circle', params: [2], hole: []}
         p = plotter({optimizePaths: false})
 
@@ -1285,11 +1285,11 @@ describe('gerber plotter', function () {
         expect(p._path.traverse()).to.eql([
           {type: 'line', start: [0, 0], end: [1, 1]},
           {type: 'line', start: [1, 3], end: [1, 1]},
-          {type: 'line', start: [3, 3], end: [1, 3]}
+          {type: 'line', start: [3, 3], end: [1, 3]},
         ])
       })
 
-      it('should update the box in non-region mode', function () {
+      it('should update the box in non-region mode', function() {
         p.write({type: 'op', op: 'int', coord: {x: 1, y: 3}})
         p.write({type: 'op', op: 'int', coord: {x: 3, y: 3}})
         p.write({type: 'op', op: 'int', coord: {x: 0, y: 0}})
@@ -1297,7 +1297,7 @@ describe('gerber plotter', function () {
         expect(p._box).to.eql([-1, -1, 4, 4])
       })
 
-      it('should update the bounding box in region mode', function () {
+      it('should update the bounding box in region mode', function() {
         p.write({type: 'set', prop: 'region', value: true})
         p.write({type: 'op', op: 'int', coord: {x: 1, y: 3}})
         p.write({type: 'op', op: 'int', coord: {x: 3, y: 3}})
@@ -1306,8 +1306,8 @@ describe('gerber plotter', function () {
         expect(p._box).to.eql([0, 0, 3, 3])
       })
 
-      describe('arc strokes', function () {
-        it('should determine the center and radius in single quadrant mode', function () {
+      describe('arc strokes', function() {
+        it('should determine the center and radius in single quadrant mode', function() {
           p.write({type: 'set', prop: 'arc', value: 's'})
           p.write({type: 'set', prop: 'mode', value: 'cw'})
           p.write({type: 'op', op: 'int', coord: {x: 2, y: 0, i: 1, j: 1.5}})
@@ -1325,7 +1325,7 @@ describe('gerber plotter', function () {
           expect(arcs[0]).to.deep.include({
             type: 'arc',
             dir: 'cw',
-            center: [1, -1.5]
+            center: [1, -1.5],
           })
           expect(arcs[0].start.slice(0, 2)).to.eql([0, 0])
           expect(arcs[0].start[2]).to.be.closeTo(2.158799, EPSILON)
@@ -1338,7 +1338,7 @@ describe('gerber plotter', function () {
           expect(arcs[1]).to.deep.include({
             type: 'arc',
             dir: 'ccw',
-            center: [3, 1.5]
+            center: [3, 1.5],
           })
           expect(arcs[1].start.slice(0, 2)).to.eql([2, 0])
           expect(arcs[1].start[2]).to.be.closeTo(4.124386, EPSILON)
@@ -1351,7 +1351,7 @@ describe('gerber plotter', function () {
           expect(arcs[2]).to.deep.include({
             type: 'arc',
             dir: 'cw',
-            center: [2.5, -1]
+            center: [2.5, -1],
           })
           expect(arcs[2].start.slice(0, 2)).to.eql([4, 0])
           expect(arcs[2].start[2]).to.be.closeTo(0.588002, EPSILON)
@@ -1364,7 +1364,7 @@ describe('gerber plotter', function () {
           expect(arcs[3]).to.deep.include({
             type: 'arc',
             dir: 'ccw',
-            center: [2.5, -1]
+            center: [2.5, -1],
           })
           expect(arcs[3].start.slice(0, 2)).to.eql([4, -2])
           expect(arcs[3].start[2]).to.be.closeTo(5.695183, EPSILON)
@@ -1374,7 +1374,7 @@ describe('gerber plotter', function () {
           expect(arcs[3].radius).to.be.closeTo(R, EPSILON)
         })
 
-        it('should use the actual offsets to get the center in multi-quadrant mode', function () {
+        it('should use the actual offsets to get the center in multi-quadrant mode', function() {
           p.write({type: 'set', prop: 'arc', value: 'm'})
           p.write({type: 'set', prop: 'mode', value: 'cw'})
           p.write({type: 'op', op: 'int', coord: {x: 2, y: 0, i: 1, j: -1.5}})
@@ -1388,7 +1388,7 @@ describe('gerber plotter', function () {
           expect(arcs[0]).to.deep.include({
             type: 'arc',
             dir: 'cw',
-            center: [1, -1.5]
+            center: [1, -1.5],
           })
           expect(arcs[0].start.slice(0, 2)).to.eql([0, 0])
           expect(arcs[0].start[2]).to.be.closeTo(2.158799, EPSILON)
@@ -1401,7 +1401,7 @@ describe('gerber plotter', function () {
           expect(arcs[1]).to.deep.include({
             type: 'arc',
             dir: 'ccw',
-            center: [3, 1.5]
+            center: [3, 1.5],
           })
           expect(arcs[1].start.slice(0, 2)).to.eql([2, 0])
           expect(arcs[1].start[2]).to.be.closeTo(4.124386, EPSILON)
@@ -1411,7 +1411,7 @@ describe('gerber plotter', function () {
           expect(arcs[1].radius).to.be.closeTo(R, EPSILON)
         })
 
-        it('should select the correct arc with an "a" coordinate', function () {
+        it('should select the correct arc with an "a" coordinate', function() {
           p.write({type: 'set', prop: 'mode', value: 'cw'})
           p.write({type: 'op', op: 'int', coord: {x: 2, y: 2, a: 2}})
           p.write({type: 'set', prop: 'mode', value: 'ccw'})
@@ -1424,7 +1424,7 @@ describe('gerber plotter', function () {
             type: 'arc',
             dir: 'cw',
             center: [2, 0],
-            radius: 2
+            radius: 2,
           })
           expect(arcs[0].start.slice(0, 2)).to.eql([0, 0])
           expect(arcs[0].start[2]).to.be.closeTo(3.141593, EPSILON)
@@ -1437,7 +1437,7 @@ describe('gerber plotter', function () {
             type: 'arc',
             dir: 'ccw',
             center: [3, 2],
-            radius: 1
+            radius: 1,
           })
           expect(arcs[1].start.slice(0, 2)).to.eql([2, 2])
           expect(arcs[1].start[2]).to.be.closeTo(3.141593, EPSILON)
@@ -1446,7 +1446,7 @@ describe('gerber plotter', function () {
           expect(arcs[1].sweep).to.be.closeTo(3.141593, EPSILON)
         })
 
-        it('should set the sweep to zero for matching start and end in single mode', function () {
+        it('should set the sweep to zero for matching start and end in single mode', function() {
           p.write({type: 'set', prop: 'arc', value: 's'})
           p.write({type: 'set', prop: 'mode', value: 'cw'})
           p.write({type: 'op', op: 'int', coord: {x: 0, y: 0, i: 1}})
@@ -1459,12 +1459,12 @@ describe('gerber plotter', function () {
               center: [-1, 0],
               sweep: 0,
               radius: 1,
-              dir: 'cw'
-            }
+              dir: 'cw',
+            },
           ])
         })
 
-        it('should set the sweep to a full circle in multi mode', function () {
+        it('should set the sweep to a full circle in multi mode', function() {
           p.write({type: 'set', prop: 'arc', value: 'm'})
           p.write({type: 'set', prop: 'mode', value: 'cw'})
           p.write({type: 'op', op: 'int', coord: {x: 0, y: 0, i: -1}})
@@ -1477,17 +1477,17 @@ describe('gerber plotter', function () {
               center: [-1, 0],
               sweep: 2 * Math.PI,
               radius: 1,
-              dir: 'cw'
-            }
+              dir: 'cw',
+            },
           ])
         })
 
-        it('should warn and not add to path if arc is impossible', function (done) {
-          p.once('warning', function (w) {
+        it('should warn and not add to path if arc is impossible', function(done) {
+          p.once('warning', function(w) {
             expect(w.message).to.match(/impossible arc/)
             expect(w.line).to.equal(12)
 
-            setTimeout(function () {
+            setTimeout(function() {
               expect(p._path.length).to.equal(0)
               done()
             }, 5)
@@ -1498,10 +1498,10 @@ describe('gerber plotter', function () {
           p.write({type: 'op', op: 'int', coord: {x: 1, y: 1, i: 1}, line: 12})
         })
 
-        it('should warn and not add to path if tool is not circular', function (done) {
-          p.once('warning', function (w) {
+        it('should warn and not add to path if tool is not circular', function(done) {
+          p.once('warning', function(w) {
             expect(w.message).to.match(/arc.*circular/)
-            setTimeout(function () {
+            setTimeout(function() {
               expect(p._path.length).to.equal(0)
               done()
             }, 5)
@@ -1514,7 +1514,7 @@ describe('gerber plotter', function () {
           p.write({type: 'op', op: 'int', coord: {x: 2, y: 0, i: 1, j: 1.5}})
         })
 
-        it('should allow non-circular tools if in region mode', function () {
+        it('should allow non-circular tools if in region mode', function() {
           var rectTool = {shape: 'rect', params: [2, 1], hole: []}
           p.write({type: 'tool', code: '11', tool: rectTool})
           p.write({type: 'set', prop: 'arc', value: 's'})
@@ -1524,15 +1524,15 @@ describe('gerber plotter', function () {
           expect(p._path.length).to.equal(1)
         })
 
-        describe('bounding box', function () {
-          it('should usually use the arc end points', function () {
+        describe('bounding box', function() {
+          it('should usually use the arc end points', function() {
             p.write({type: 'op', op: 'move', coord: {x: 0.5, y: 0.866}})
             p.write({type: 'set', prop: 'mode', value: 'cw'})
             p.write({type: 'set', prop: 'arc', value: 's'})
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.866, y: 0.5, i: 0.5, j: 0.866}
+              coord: {x: 0.866, y: 0.5, i: 0.5, j: 0.866},
             })
             expect(p._box).to.eql([-0.5, -0.5, 1.866, 1.866])
 
@@ -1542,19 +1542,19 @@ describe('gerber plotter', function () {
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.866, y: 0.5, i: 0.5, j: 0.866}
+              coord: {x: 0.866, y: 0.5, i: 0.5, j: 0.866},
             })
             expect(p._box).to.eql([0.5, 0.5, 0.866, 0.866])
           })
 
-          it('should should set the min x when arc sweeps past 180 deg', function () {
+          it('should should set the min x when arc sweeps past 180 deg', function() {
             p.write({type: 'op', op: 'move', coord: {x: -0.7071, y: -0.7071}})
             p.write({type: 'set', prop: 'mode', value: 'cw'})
             p.write({type: 'set', prop: 'arc', value: 's'})
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: -0.7071, y: 0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: -0.7071, y: 0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[0]).to.be.closeTo(-2, 0.00001)
 
@@ -1564,19 +1564,19 @@ describe('gerber plotter', function () {
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: -0.7071, y: 0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: -0.7071, y: 0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[0]).to.be.closeTo(-1, 0.00001)
           })
 
-          it('should should set the min y when arc sweeps past 270 deg', function () {
+          it('should should set the min y when arc sweeps past 270 deg', function() {
             p.write({type: 'op', op: 'move', coord: {x: -0.7071, y: -0.7071}})
             p.write({type: 'set', prop: 'mode', value: 'ccw'})
             p.write({type: 'set', prop: 'arc', value: 's'})
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.7071, y: -0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: 0.7071, y: -0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[1]).to.be.closeTo(-2, 0.00001)
 
@@ -1586,19 +1586,19 @@ describe('gerber plotter', function () {
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.7071, y: -0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: 0.7071, y: -0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[1]).to.be.closeTo(-1, 0.00001)
           })
 
-          it('should should set the max x when arc sweeps past 0 deg', function () {
+          it('should should set the max x when arc sweeps past 0 deg', function() {
             p.write({type: 'op', op: 'move', coord: {x: 0.7071, y: -0.7071}})
             p.write({type: 'set', prop: 'mode', value: 'ccw'})
             p.write({type: 'set', prop: 'arc', value: 's'})
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[2]).to.be.closeTo(2, 0.00001)
 
@@ -1608,19 +1608,19 @@ describe('gerber plotter', function () {
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[2]).to.be.closeTo(1, 0.00001)
           })
 
-          it('should should set the max y when arc sweeps past 90 deg', function () {
+          it('should should set the max y when arc sweeps past 90 deg', function() {
             p.write({type: 'op', op: 'move', coord: {x: -0.7071, y: 0.7071}})
             p.write({type: 'set', prop: 'mode', value: 'cw'})
             p.write({type: 'set', prop: 'arc', value: 's'})
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[3]).to.be.closeTo(2, 0.00001)
 
@@ -1630,12 +1630,12 @@ describe('gerber plotter', function () {
             p.write({
               type: 'op',
               op: 'int',
-              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071}
+              coord: {x: 0.7071, y: 0.7071, i: 0.7071, j: 0.7071},
             })
             expect(p._box[3]).to.be.closeTo(1, 0.00001)
           })
 
-          it('should set the box properly for a full circle', function () {
+          it('should set the box properly for a full circle', function() {
             p.write({type: 'set', prop: 'mode', value: 'cw'})
             p.write({type: 'set', prop: 'arc', value: 'm'})
             p.write({type: 'op', op: 'int', coord: {x: 0, y: 0, i: -1, j: 0}})
@@ -1650,26 +1650,26 @@ describe('gerber plotter', function () {
       })
     })
 
-    describe('interpolating with rectangular tools', function () {
-      beforeEach(function () {
+    describe('interpolating with rectangular tools', function() {
+      beforeEach(function() {
         var rectTool = {shape: 'rect', params: [2, 1], hole: []}
         p.write({type: 'tool', code: '11', tool: rectTool})
       })
 
-      it('should directly emit fills without adding to the path for rect tools', function (done) {
+      it('should directly emit fills without adding to the path for rect tools', function(done) {
         var path = [
           {type: 'line', start: [-1, -0.5], end: [1, -0.5]},
           {type: 'line', start: [1, -0.5], end: [1, 0.5]},
           {type: 'line', start: [1, 0.5], end: [-1, 0.5]},
-          {type: 'line', start: [-1, 0.5], end: [-1, -0.5]}
+          {type: 'line', start: [-1, 0.5], end: [-1, -0.5]},
         ]
 
-        p.once('readable', function () {
+        p.once('readable', function() {
           var result = p.read()
           expect(p._path.length).to.equal(0)
           expect(result).to.eql({type: 'fill', path: path})
 
-          setTimeout(function () {
+          setTimeout(function() {
             expect(p._box).to.eql([-1, -0.5, 1, 0.5])
             done()
           }, 1)
@@ -1678,22 +1678,22 @@ describe('gerber plotter', function () {
         p.write({type: 'op', op: 'int', coord: {x: 0, y: 0}})
       })
 
-      it('should handle a first quadrant move', function (done) {
+      it('should handle a first quadrant move', function(done) {
         var path = [
           {type: 'line', start: [-1, -0.5], end: [1, -0.5]},
           {type: 'line', start: [1, -0.5], end: [6, 4.5]},
           {type: 'line', start: [6, 4.5], end: [6, 5.5]},
           {type: 'line', start: [6, 5.5], end: [4, 5.5]},
           {type: 'line', start: [4, 5.5], end: [-1, 0.5]},
-          {type: 'line', start: [-1, 0.5], end: [-1, -0.5]}
+          {type: 'line', start: [-1, 0.5], end: [-1, -0.5]},
         ]
 
-        p.once('readable', function () {
+        p.once('readable', function() {
           var result = p.read()
           expect(p._path.length).to.equal(0)
           expect(result).to.eql({type: 'fill', path: path})
 
-          setTimeout(function () {
+          setTimeout(function() {
             expect(p._box).to.eql([-1, -0.5, 6, 5.5])
             done()
           }, 1)
@@ -1702,22 +1702,22 @@ describe('gerber plotter', function () {
         p.write({type: 'op', op: 'int', coord: {x: 5, y: 5}})
       })
 
-      it('should handle a second quadrant move', function (done) {
+      it('should handle a second quadrant move', function(done) {
         var path = [
           {type: 'line', start: [1, -0.5], end: [1, 0.5]},
           {type: 'line', start: [1, 0.5], end: [-4, 5.5]},
           {type: 'line', start: [-4, 5.5], end: [-6, 5.5]},
           {type: 'line', start: [-6, 5.5], end: [-6, 4.5]},
           {type: 'line', start: [-6, 4.5], end: [-1, -0.5]},
-          {type: 'line', start: [-1, -0.5], end: [1, -0.5]}
+          {type: 'line', start: [-1, -0.5], end: [1, -0.5]},
         ]
 
-        p.once('readable', function () {
+        p.once('readable', function() {
           var result = p.read()
           expect(p._path.length).to.equal(0)
           expect(result).to.eql({type: 'fill', path: path})
 
-          setTimeout(function () {
+          setTimeout(function() {
             expect(p._box).to.eql([-6, -0.5, 1, 5.5])
             done()
           }, 1)
@@ -1726,22 +1726,22 @@ describe('gerber plotter', function () {
         p.write({type: 'op', op: 'int', coord: {x: -5, y: 5}})
       })
 
-      it('should handle a third quadrant move', function (done) {
+      it('should handle a third quadrant move', function(done) {
         var path = [
           {type: 'line', start: [1, 0.5], end: [-1, 0.5]},
           {type: 'line', start: [-1, 0.5], end: [-6, -4.5]},
           {type: 'line', start: [-6, -4.5], end: [-6, -5.5]},
           {type: 'line', start: [-6, -5.5], end: [-4, -5.5]},
           {type: 'line', start: [-4, -5.5], end: [1, -0.5]},
-          {type: 'line', start: [1, -0.5], end: [1, 0.5]}
+          {type: 'line', start: [1, -0.5], end: [1, 0.5]},
         ]
 
-        p.once('readable', function () {
+        p.once('readable', function() {
           var result = p.read()
           expect(p._path.length).to.equal(0)
           expect(result).to.eql({type: 'fill', path: path})
 
-          setTimeout(function () {
+          setTimeout(function() {
             expect(p._box).to.eql([-6, -5.5, 1, 0.5])
             done()
           }, 1)
@@ -1750,22 +1750,22 @@ describe('gerber plotter', function () {
         p.write({type: 'op', op: 'int', coord: {x: -5, y: -5}})
       })
 
-      it('should handle a fourth quadrant move', function (done) {
+      it('should handle a fourth quadrant move', function(done) {
         var path = [
           {type: 'line', start: [-1, 0.5], end: [-1, -0.5]},
           {type: 'line', start: [-1, -0.5], end: [4, -5.5]},
           {type: 'line', start: [4, -5.5], end: [6, -5.5]},
           {type: 'line', start: [6, -5.5], end: [6, -4.5]},
           {type: 'line', start: [6, -4.5], end: [1, 0.5]},
-          {type: 'line', start: [1, 0.5], end: [-1, 0.5]}
+          {type: 'line', start: [1, 0.5], end: [-1, 0.5]},
         ]
 
-        p.once('readable', function () {
+        p.once('readable', function() {
           var result = p.read()
           expect(p._path.length).to.equal(0)
           expect(result).to.eql({type: 'fill', path: path})
 
-          setTimeout(function () {
+          setTimeout(function() {
             expect(p._box).to.eql([-1, -5.5, 6, 0.5])
             done()
           }, 1)
@@ -1774,23 +1774,23 @@ describe('gerber plotter', function () {
         p.write({type: 'op', op: 'int', coord: {x: 5, y: -5}})
       })
 
-      it('should do a normal stroke if region mode is on', function (done) {
+      it('should do a normal stroke if region mode is on', function(done) {
         p._region = true
         p.write({type: 'op', op: 'int', coord: {x: 5, y: 5}})
 
-        setTimeout(function () {
+        setTimeout(function() {
           expect(p._path.traverse()).to.eql([
-            {type: 'line', start: [0, 0], end: [5, 5]}
+            {type: 'line', start: [0, 0], end: [5, 5]},
           ])
           done()
         }, 10)
       })
     })
 
-    it('should allow but warn about modal operation codes', function (done) {
-      p.once('warning', function (w) {
+    it('should allow but warn about modal operation codes', function(done) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/modal operation/)
-        setTimeout(function () {
+        setTimeout(function() {
           expect(p._path.length).to.equal(2)
           done()
         }, 5)
@@ -1801,15 +1801,15 @@ describe('gerber plotter', function () {
     })
   })
 
-  describe('operation warnings', function () {
-    beforeEach(function () {
+  describe('operation warnings', function() {
+    beforeEach(function() {
       var tool = {shape: 'circle', params: [2], hole: []}
       p.write({type: 'set', prop: 'epsilon', value: 0.00000001})
       p.write({type: 'tool', code: '10', tool: tool})
     })
 
-    it('should warn and use backup units if the units are not set', function (done) {
-      p.once('warning', function (w) {
+    it('should warn and use backup units if the units are not set', function(done) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/backup units/)
         done()
       })
@@ -1819,8 +1819,8 @@ describe('gerber plotter', function () {
       p.write({type: 'op', op: 'int', coord: {x: 1, y: 1}})
     })
 
-    it('should warn and use backup notation if the notation is not set', function (done) {
-      p.once('warning', function (w) {
+    it('should warn and use backup notation if the notation is not set', function(done) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/backup notation/)
         done()
       })
@@ -1830,8 +1830,8 @@ describe('gerber plotter', function () {
       p.write({type: 'op', op: 'int', coord: {x: 1, y: 1}})
     })
 
-    it('should warn if a tool is flashed in region mode', function (done) {
-      p.once('warning', function (w) {
+    it('should warn if a tool is flashed in region mode', function(done) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/flash in region/)
         done()
       })
@@ -1842,8 +1842,8 @@ describe('gerber plotter', function () {
       p.write({type: 'op', op: 'flash', coord: {x: 1, y: 1}})
     })
 
-    it('should warn if a non-existent tool is flashed', function (done) {
-      p.once('warning', function (w) {
+    it('should warn if a non-existent tool is flashed', function(done) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/unknown tool/)
         done()
       })
@@ -1854,13 +1854,13 @@ describe('gerber plotter', function () {
       p.write({type: 'op', op: 'flash', coord: {x: 1, y: 1}})
     })
 
-    it('should warn and ignore interpolates with unstrokable tools', function (done) {
+    it('should warn and ignore interpolates with unstrokable tools', function(done) {
       var tool = {shape: 'circle', params: [2], hole: [1]}
 
-      p.once('warning', function (w) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/not strokable/)
 
-        setTimeout(function () {
+        setTimeout(function() {
           expect(p._path.length).to.equal(0)
           done()
         }, 5)
@@ -1873,10 +1873,10 @@ describe('gerber plotter', function () {
       p.write({type: 'op', op: 'int', coord: {x: 1, y: 1}})
     })
 
-    it('should warn and assume linear interpolation mode if unspecified', function (done) {
-      p.once('warning', function (w) {
+    it('should warn and assume linear interpolation mode if unspecified', function(done) {
+      p.once('warning', function(w) {
         expect(w.message).to.match(/no interpolation.*linear/)
-        setTimeout(function () {
+        setTimeout(function() {
           expect(p._path.length).to.equal(1)
           done()
         }, 5)
@@ -1887,10 +1887,10 @@ describe('gerber plotter', function () {
       p.write({type: 'op', op: 'int', coord: {x: 1, y: 1}})
     })
 
-    it('should warn and assume single-quadrant mode if unspecified', function (done) {
-      p.on('warning', function (w) {
+    it('should warn and assume single-quadrant mode if unspecified', function(done) {
+      p.on('warning', function(w) {
         expect(w.message).to.match(/assuming single quadrant/)
-        setTimeout(function () {
+        setTimeout(function() {
           expect(p._arc).to.equal('s')
           expect(p._path.length).to.equal(1)
           done()
@@ -1904,27 +1904,27 @@ describe('gerber plotter', function () {
     })
   })
 
-  describe('emitting strokes and regions', function () {
+  describe('emitting strokes and regions', function() {
     var path = [
       {type: 'line', start: [0, 0], end: [1, 0]},
       {type: 'line', start: [1, 0], end: [1, 1]},
       {type: 'line', start: [1, 1], end: [0, 1]},
-      {type: 'line', start: [0, 1], end: [0, 0]}
+      {type: 'line', start: [0, 1], end: [0, 0]},
     ]
 
-    beforeEach(function () {
+    beforeEach(function() {
       var tool0 = {shape: 'circle', params: [0.2], hole: []}
       var tool1 = {shape: 'circle', params: [0.4], hole: []}
       p.write({type: 'tool', code: '11', tool: tool1})
       p.write({type: 'tool', code: '10', tool: tool0})
 
-      path.forEach(function (path) {
+      path.forEach(function(path) {
         p._path.add(path)
       })
     })
 
-    it('should end the path on a tool change', function (done) {
-      p.once('data', function () {
+    it('should end the path on a tool change', function(done) {
+      p.once('data', function() {
         expect(p._path.length).to.equal(0)
         done()
       })
@@ -1932,10 +1932,10 @@ describe('gerber plotter', function () {
       p.write({type: 'set', prop: 'tool', value: '10'})
     })
 
-    it('should end the path on a tool definition', function (done) {
+    it('should end the path on a tool definition', function(done) {
       var tool = {shape: 'circle', params: [0.1], hole: []}
 
-      p.once('data', function () {
+      p.once('data', function() {
         expect(p._path.length).to.equal(0)
         done()
       })
@@ -1943,8 +1943,8 @@ describe('gerber plotter', function () {
       p.write({type: 'tool', code: '12', tool: tool})
     })
 
-    it('should end the path on a region change', function (done) {
-      p.once('data', function () {
+    it('should end the path on a region change', function(done) {
+      p.once('data', function() {
         expect(p._path.length).to.equal(0)
         done()
       })
@@ -1952,8 +1952,8 @@ describe('gerber plotter', function () {
       p.write({type: 'set', prop: 'region', value: true})
     })
 
-    it('should end the path on a polarity change', function (done) {
-      p.once('data', function () {
+    it('should end the path on a polarity change', function(done) {
+      p.once('data', function() {
         expect(p._path.length).to.equal(0)
         done()
       })
@@ -1961,8 +1961,8 @@ describe('gerber plotter', function () {
       p.write({type: 'level', level: 'polarity', value: 'C'})
     })
 
-    it('should end the path on a step repeat', function (done) {
-      p.once('data', function () {
+    it('should end the path on a step repeat', function(done) {
+      p.once('data', function() {
         expect(p._path.length).to.equal(0)
         done()
       })
@@ -1970,12 +1970,12 @@ describe('gerber plotter', function () {
       p.write({
         type: 'level',
         level: 'stepRep',
-        value: {x: 5, y: 5, i: 2, j: 2}
+        value: {x: 5, y: 5, i: 2, j: 2},
       })
     })
 
-    it('should end the path on stream end', function (done) {
-      p.once('data', function () {
+    it('should end the path on stream end', function(done) {
+      p.once('data', function() {
         expect(p._path.length).to.equal(0)
         done()
       })
@@ -1983,14 +1983,14 @@ describe('gerber plotter', function () {
       p.end()
     })
 
-    it('should emit a stroke if region mode it off', function (done) {
+    it('should emit a stroke if region mode it off', function(done) {
       var expected = {
         type: 'stroke',
         width: 0.2,
-        path: path
+        path: path,
       }
 
-      p.once('readable', function () {
+      p.once('readable', function() {
         var data = p.read()
         expect(data).to.eql(expected)
         done()
@@ -1999,10 +1999,10 @@ describe('gerber plotter', function () {
       p._finishPath()
     })
 
-    it('should emit a fill if region mode is on', function (done) {
+    it('should emit a fill if region mode is on', function(done) {
       var expected = {type: 'fill', path: path}
 
-      p.once('readable', function () {
+      p.once('readable', function() {
         var data = p.read()
         expect(data).to.eql(expected)
         done()
@@ -2013,15 +2013,15 @@ describe('gerber plotter', function () {
     })
   })
 
-  describe('emitting new layers', function () {
-    it('should push a polarity change with the current bounding box', function (done) {
+  describe('emitting new layers', function() {
+    it('should push a polarity change with the current bounding box', function(done) {
       var results = 0
       var expected = [
         {type: 'polarity', polarity: 'clear', box: [0, 0, 10, 10]},
-        {type: 'polarity', polarity: 'dark', box: [0, 0, 10, 10]}
+        {type: 'polarity', polarity: 'dark', box: [0, 0, 10, 10]},
       ]
 
-      var handleData = function (data) {
+      var handleData = function(data) {
         expect(data).to.eql(expected[results])
         if (++results >= expected.length) {
           p.removeListener('data', handleData)
@@ -2035,8 +2035,8 @@ describe('gerber plotter', function () {
       p.write({type: 'level', level: 'polarity', value: 'D'})
     })
 
-    it('should push a step repeat with the current bounding box', function (done) {
-      p.once('readable', function () {
+    it('should push a step repeat with the current bounding box', function(done) {
+      p.once('readable', function() {
         var result = p.read()
         expect(result).to.eql({
           type: 'repeat',
@@ -2046,9 +2046,9 @@ describe('gerber plotter', function () {
             [0, 4.4],
             [3.3, 0],
             [3.3, 2.2],
-            [3.3, 4.4]
+            [3.3, 4.4],
           ],
-          box: [0, 0, 10, 10]
+          box: [0, 0, 10, 10],
         })
         done()
       })
@@ -2057,26 +2057,26 @@ describe('gerber plotter', function () {
       p.write({
         type: 'level',
         level: 'stepRep',
-        value: {x: 2, y: 3, i: 3.3, j: 2.2}
+        value: {x: 2, y: 3, i: 3.3, j: 2.2},
       })
     })
 
-    it('should update the box during a step repeat', function () {
+    it('should update the box during a step repeat', function() {
       var tool = {shape: 'circle', params: [2], hole: []}
       p.write({type: 'tool', code: '10', tool: tool})
       p.write({
         type: 'level',
         level: 'stepRep',
-        value: {x: 2, y: 2, i: 3.5, j: -3}
+        value: {x: 2, y: 2, i: 3.5, j: -3},
       })
       p.write({type: 'op', op: 'flash', coord: {x: -3, y: 4}})
       expect(p._box).to.eql([-4, 0, 1.5, 5])
     })
   })
 
-  describe('ending the stream', function () {
-    it('should push a size object after the stream ends', function (done) {
-      p.once('readable', function () {
+  describe('ending the stream', function() {
+    it('should push a size object after the stream ends', function(done) {
+      p.once('readable', function() {
         var result = p.read()
         expect(result).to.eql({type: 'size', box: [1, 2, 3, 4], units: 'in'})
         done()
@@ -2088,10 +2088,10 @@ describe('gerber plotter', function () {
     })
   })
 
-  describe('outline mode', function () {
+  describe('outline mode', function() {
     var outPlotter
     var tool
-    beforeEach(function () {
+    beforeEach(function() {
       tool = {shape: 'circle', params: [2], hole: []}
 
       outPlotter = plotter({plotAsOutline: true})
@@ -2102,7 +2102,7 @@ describe('gerber plotter', function () {
       outPlotter.write({type: 'tool', code: '10', tool: tool})
     })
 
-    it('should update the bounding box in as if it was region mode', function () {
+    it('should update the bounding box in as if it was region mode', function() {
       outPlotter.write({type: 'op', op: 'int', coord: {x: 1, y: 3}})
       outPlotter.write({type: 'op', op: 'int', coord: {x: 3, y: 3}})
       outPlotter.write({type: 'op', op: 'int', coord: {x: 0, y: 0}})
@@ -2110,7 +2110,7 @@ describe('gerber plotter', function () {
       expect(outPlotter._box).to.eql([0, 0, 3, 3])
     })
 
-    it('should set the tool to the first used tool and never change it', function () {
+    it('should set the tool to the first used tool and never change it', function() {
       var newTool = {shape: 'circle', params: [4], hole: []}
       var newerTool = {shape: 'circle', params: [6], hole: []}
 
@@ -2125,23 +2125,23 @@ describe('gerber plotter', function () {
       expect(outPlotter._tool.code).to.equal('10')
     })
 
-    it('should fill gaps in paths if in outline mode', function () {
+    it('should fill gaps in paths if in outline mode', function() {
       expect(!outPlotter._path._fillGaps).to.equal(false)
       outPlotter.write({type: 'op', op: 'int', coord: {x: 1, y: 3}})
       outPlotter._finishPath()
       expect(!outPlotter._path._fillGaps).to.equal(false)
     })
 
-    it('should be able to set a custom max gap size', function () {
+    it('should be able to set a custom max gap size', function() {
       outPlotter = plotter({plotAsOutline: 0.0011, units: 'mm'})
       expect(outPlotter._path._fillGaps).to.equal(0.0011)
     })
   })
 
-  describe('path optimization', function () {
+  describe('path optimization', function() {
     var optimizedPlotter
     var tool
-    beforeEach(function () {
+    beforeEach(function() {
       tool = {shape: 'circle', params: [2], hole: []}
 
       optimizedPlotter = plotter({optimizePaths: true})
@@ -2152,14 +2152,14 @@ describe('gerber plotter', function () {
       optimizedPlotter.write({type: 'tool', code: '10', tool: tool})
     })
 
-    it('should set the path to optimize', function () {
+    it('should set the path to optimize', function() {
       expect(optimizedPlotter._path._optimize).to.equal(true)
       optimizedPlotter.write({type: 'op', op: 'int', coord: {x: 1, y: 3}})
       optimizedPlotter._finishPath()
       expect(optimizedPlotter._path._optimize).to.equal(true)
     })
 
-    it('should not optimize in region mode', function () {
+    it('should not optimize in region mode', function() {
       optimizedPlotter.write({type: 'set', prop: 'region', value: true})
       expect(optimizedPlotter._path._optimize).to.equal(false)
       optimizedPlotter.write({type: 'set', prop: 'region', value: false})

--- a/packages/gerber-plotter/test/path-graph_test.js
+++ b/packages/gerber-plotter/test/path-graph_test.js
@@ -5,17 +5,17 @@ var expect = require('chai').expect
 
 var PathGraph = require('../lib/path-graph')
 
-describe('path graphs', function () {
+describe('path graphs', function() {
   var p
-  beforeEach(function () {
+  beforeEach(function() {
     p = new PathGraph(true)
   })
 
-  it('should be able to traverse', function () {
+  it('should be able to traverse', function() {
     expect(p.traverse()).to.eql([])
   })
 
-  it('should be able to add to and traverse a path graph', function () {
+  it('should be able to add to and traverse a path graph', function() {
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
     p.add({type: 'line', start: [1, 0], end: [1, 1]})
     p.add({type: 'line', start: [1, 1], end: [0, 1]})
@@ -25,21 +25,21 @@ describe('path graphs', function () {
       {type: 'line', start: [0, 0], end: [1, 0]},
       {type: 'line', start: [1, 0], end: [1, 1]},
       {type: 'line', start: [1, 1], end: [0, 1]},
-      {type: 'line', start: [0, 1], end: [0, 0]}
+      {type: 'line', start: [0, 1], end: [0, 0]},
     ])
   })
 
-  it('should reverse line segments during traversal', function () {
+  it('should reverse line segments during traversal', function() {
     p.add({type: 'line', start: [0, 0], end: [1, 1]})
     p.add({type: 'line', start: [1, 0], end: [1, 1]})
 
     expect(p.traverse()).to.eql([
       {type: 'line', start: [0, 0], end: [1, 1]},
-      {type: 'line', start: [1, 1], end: [1, 0]}
+      {type: 'line', start: [1, 1], end: [1, 0]},
     ])
   })
 
-  it('should traverse multiple trees', function () {
+  it('should traverse multiple trees', function() {
     p.add({type: 'line', start: [0, 0], end: [1, 1]})
     p.add({type: 'line', start: [1, 1], end: [1, 2]})
     p.add({type: 'line', start: [2, 2], end: [3, 3]})
@@ -49,14 +49,14 @@ describe('path graphs', function () {
       {type: 'line', start: [0, 0], end: [1, 1]},
       {type: 'line', start: [1, 1], end: [1, 2]},
       {type: 'line', start: [2, 2], end: [3, 3]},
-      {type: 'line', start: [3, 3], end: [3, 4]}
+      {type: 'line', start: [3, 3], end: [3, 4]},
     ])
   })
 
   // depth first traversal is used so that when converted to an SVG path it
   // retains its shape. see discussion:
   // https://github.com/mcous/gerber-plotter/pull/13
-  it('should traverse the graph depth first', function () {
+  it('should traverse the graph depth first', function() {
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
     p.add({type: 'line', start: [0, 0], end: [-1, 0]})
     p.add({type: 'line', start: [0, 1], end: [1, 1]})
@@ -74,11 +74,11 @@ describe('path graphs', function () {
       {type: 'line', start: [0, 0], end: [-1, 0]},
       {type: 'line', start: [-1, 0], end: [-1, -1]},
       {type: 'line', start: [-1, -1], end: [0, -1]},
-      {type: 'line', start: [0, -1], end: [0, 0]}
+      {type: 'line', start: [0, -1], end: [0, 0]},
     ])
   })
 
-  it('should reverse arc segments during traversal', function () {
+  it('should reverse arc segments during traversal', function() {
     var HALF_PI = Math.PI / 2
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
     p.add({
@@ -88,7 +88,7 @@ describe('path graphs', function () {
       center: [1, 1],
       sweep: HALF_PI,
       radius: 1,
-      dir: 'cw'
+      dir: 'cw',
     })
     p.add({
       type: 'arc',
@@ -97,7 +97,7 @@ describe('path graphs', function () {
       center: [3, 1],
       sweep: HALF_PI,
       radius: 1,
-      dir: 'ccw'
+      dir: 'ccw',
     })
 
     expect(p.traverse()).to.eql([
@@ -109,7 +109,7 @@ describe('path graphs', function () {
         center: [1, 1],
         sweep: HALF_PI,
         radius: 1,
-        dir: 'ccw'
+        dir: 'ccw',
       },
       {
         type: 'arc',
@@ -118,12 +118,12 @@ describe('path graphs', function () {
         center: [3, 1],
         sweep: HALF_PI,
         radius: 1,
-        dir: 'cw'
-      }
+        dir: 'cw',
+      },
     ])
   })
 
-  it('should have a length property', function () {
+  it('should have a length property', function() {
     expect(p.length).to.equal(0)
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
     p.add({type: 'line', start: [0, 0], end: [-1, 0]})
@@ -131,7 +131,7 @@ describe('path graphs', function () {
     expect(p.length).to.equal(3)
   })
 
-  it('should not allow duplicate line segments', function () {
+  it('should not allow duplicate line segments', function() {
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
     p.add({type: 'line', start: [1, 0], end: [0, 0]})
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
@@ -139,7 +139,7 @@ describe('path graphs', function () {
     expect(p.length).to.equal(1)
   })
 
-  it('should not allow duplicate line segments but it should continue', function () {
+  it('should not allow duplicate line segments but it should continue', function() {
     p.add({type: 'line', start: [1, 0], end: [1, 2]})
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
     p.add({type: 'line', start: [1, 0], end: [0, 0]})
@@ -152,7 +152,7 @@ describe('path graphs', function () {
     expect(p.length).to.equal(4)
   })
 
-  it('should not optimize the path if passed a false during construction', function () {
+  it('should not optimize the path if passed a false during construction', function() {
     p = new PathGraph(false)
 
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
@@ -172,11 +172,11 @@ describe('path graphs', function () {
       {type: 'line', start: [0, 0], end: [0, 1]},
       {type: 'line', start: [0, 0], end: [0, -1]},
       {type: 'line', start: [1, 0], end: [1, 1]},
-      {type: 'line', start: [-1, 0], end: [-1, -1]}
+      {type: 'line', start: [-1, 0], end: [-1, -1]},
     ])
   })
 
-  it('should be able to fill gaps', function () {
+  it('should be able to fill gaps', function() {
     p = new PathGraph(true, 0.00011)
 
     p.add({type: 'line', start: [0, 0], end: [1.0001, 0]})
@@ -188,11 +188,11 @@ describe('path graphs', function () {
       {type: 'line', start: [0, 0], end: [1, 0]},
       {type: 'line', start: [1, 0], end: [1, 1]},
       {type: 'line', start: [1, 1], end: [0, 1]},
-      {type: 'line', start: [0, 1], end: [0, 0]}
+      {type: 'line', start: [0, 1], end: [0, 0]},
     ])
   })
 
-  it('should be able to fill gaps with a specified gap distance', function () {
+  it('should be able to fill gaps with a specified gap distance', function() {
     p = new PathGraph(true, 0.0011)
 
     p.add({type: 'line', start: [0, 0], end: [1.001, 0]})
@@ -204,11 +204,11 @@ describe('path graphs', function () {
       {type: 'line', start: [0, 0], end: [1, 0]},
       {type: 'line', start: [1, 0], end: [1, 1]},
       {type: 'line', start: [1, 1], end: [0, 1]},
-      {type: 'line', start: [0, 1], end: [0, 0]}
+      {type: 'line', start: [0, 1], end: [0, 0]},
     ])
   })
 
-  it('should find the closest point when filling gaps', function () {
+  it('should find the closest point when filling gaps', function() {
     p = new PathGraph(true, 0.06)
 
     p.add({type: 'line', start: [0, 0], end: [1, 0]})
@@ -220,7 +220,7 @@ describe('path graphs', function () {
       {type: 'line', start: [0, 0], end: [1.01, 0]},
       {type: 'line', start: [1.01, 0], end: [1.03, 0]},
       {type: 'line', start: [1.03, 0], end: [1.04, 0.01]},
-      {type: 'line', start: [1.04, 0.01], end: [2, 2]}
+      {type: 'line', start: [1.04, 0.01], end: [2, 2]},
     ])
   })
 })

--- a/packages/gerber-to-svg/example/index.js
+++ b/packages/gerber-to-svg/example/index.js
@@ -17,7 +17,7 @@ const GERBER_PATHS = [
   path.join(GERBERS_DIR, 'arduino-uno.plc'),
   path.join(GERBERS_DIR, 'arduino-uno.sol'),
   path.join(GERBERS_DIR, 'arduino-uno.stc'),
-  path.join(GERBERS_DIR, 'arduino-uno.sts')
+  path.join(GERBERS_DIR, 'arduino-uno.sts'),
 ]
 
 GERBER_PATHS.forEach(filename => {

--- a/packages/gerber-to-svg/integration/gerber-to-svg-snapshot.test.js
+++ b/packages/gerber-to-svg/integration/gerber-to-svg-snapshot.test.js
@@ -9,16 +9,16 @@ const getResults = require('./get-results')
 
 const SUITES = [
   ...getGerberSpecs.sync(),
-  ...getBoards.sync().filter(b => !b.skipSnapshot)
+  ...getBoards.sync().filter(b => !b.skipSnapshot),
 ]
 
-describe(`gerber-to-svg :: integration`, function () {
+describe(`gerber-to-svg :: integration`, function() {
   SUITES.forEach(suite =>
-    describe(suite.name, function () {
+    describe(suite.name, function() {
       const specs = suite.specs || suite.layers
       let suiteResults
 
-      before(function (done) {
+      before(function(done) {
         if (process.env.INTEGRATION !== '1') return this.skip()
 
         getResults(suite, (error, results) => {
@@ -29,7 +29,7 @@ describe(`gerber-to-svg :: integration`, function () {
       })
 
       specs.forEach((spec, i) =>
-        it(`renders ${spec.name}`, function () {
+        it(`renders ${spec.name}`, function() {
           const result = suiteResults.specs[i]
           snapshot(format(result.render).split('\n'))
         })

--- a/packages/gerber-to-svg/integration/get-results.js
+++ b/packages/gerber-to-svg/integration/get-results.js
@@ -9,7 +9,7 @@ const debug = require('debug')('tracespace/gerber-to-svg/integration')
 const wtg = require('whats-that-gerber')
 const gerberToSvg = require('..')
 
-module.exports = function getSuiteResults (suite, done) {
+module.exports = function getSuiteResults(suite, done) {
   debug(`Rendering suite ${suite.name}`)
 
   const specs = suite.specs || suite.layers
@@ -18,19 +18,19 @@ module.exports = function getSuiteResults (suite, done) {
   runWaterfall(
     [
       next => runParallel(specTasks, next),
-      (specs, next) => next(null, Object.assign(suite, {specs}))
+      (specs, next) => next(null, Object.assign(suite, {specs})),
     ],
     done
   )
 }
 
-function renderSpec (spec, done) {
+function renderSpec(spec, done) {
   debug(`Rendering ${spec.category} - ${spec.name}`)
 
   const renderOptions = Object.assign(
     {
       id: path.basename(spec.filepath),
-      plotAsOutline: spec.type === wtg.TYPE_OUTLINE
+      plotAsOutline: spec.type === wtg.TYPE_OUTLINE,
     },
     spec.options
   )
@@ -38,7 +38,7 @@ function renderSpec (spec, done) {
   runWaterfall(
     [
       next => gerberToSvg(spec.source, renderOptions, next),
-      (render, next) => next(null, Object.assign({render}, spec))
+      (render, next) => next(null, Object.assign({render}, spec)),
     ],
     done
   )

--- a/packages/gerber-to-svg/lib/_create-path.js
+++ b/packages/gerber-to-svg/lib/_create-path.js
@@ -4,21 +4,21 @@
 var util = require('./_util')
 var shift = util.shift
 
-var pointsEqual = function (point, target) {
+var pointsEqual = function(point, target) {
   return point[0] === target[0] && point[1] === target[1]
 }
 
-var move = function (start) {
+var move = function(start) {
   return 'M ' + shift(start[0]) + ' ' + shift(start[1])
 }
 
-var line = function (lastCmd, end) {
+var line = function(lastCmd, end) {
   var cmd = lastCmd === 'L' || lastCmd === 'M' ? '' : 'L '
 
   return cmd + shift(end[0]) + ' ' + shift(end[1])
 }
 
-var arc = function (lastCmd, radius, sweep, dir, end, center) {
+var arc = function(lastCmd, radius, sweep, dir, end, center) {
   // add zero-length arcs as zero-length lines to render properly across all browsers
   if (sweep === 0) {
     return line(lastCmd, end)
@@ -45,7 +45,7 @@ var arc = function (lastCmd, radius, sweep, dir, end, center) {
   return result
 }
 
-var reduceSegments = function (result, segment) {
+var reduceSegments = function(result, segment) {
   var type = segment.type
   var start = segment.start
   var end = segment.end
@@ -77,7 +77,7 @@ var reduceSegments = function (result, segment) {
   return result
 }
 
-module.exports = function createPath (segments, width, element) {
+module.exports = function createPath(segments, width, element) {
   var pathData = segments.reduce(reduceSegments, {last: [], data: ''}).data
   var attr = {d: pathData}
 

--- a/packages/gerber-to-svg/lib/_flash-pad.js
+++ b/packages/gerber-to-svg/lib/_flash-pad.js
@@ -4,7 +4,7 @@
 var util = require('./_util')
 var shift = util.shift
 
-module.exports = function flashPad (prefix, tool, x, y, element) {
+module.exports = function flashPad(prefix, tool, x, y, element) {
   var toolId = '#' + prefix + '_pad-' + tool
 
   return element('use', {'xlink:href': toolId, x: shift(x), y: shift(y)})

--- a/packages/gerber-to-svg/lib/_reduce-shape.js
+++ b/packages/gerber-to-svg/lib/_reduce-shape.js
@@ -6,15 +6,15 @@ var shift = util.shift
 var createMask = util.createMask
 var maskLayer = util.maskLayer
 
-var element = function (tag, attr, children) {
+var element = function(tag, attr, children) {
   return {tag: tag, attr: attr, children: children || []}
 }
 
-var circle = function (cx, cy, r, width) {
+var circle = function(cx, cy, r, width) {
   var attr = {
     cx: shift(cx),
     cy: shift(cy),
-    r: shift(r)
+    r: shift(r),
   }
 
   if (width != null) {
@@ -25,12 +25,12 @@ var circle = function (cx, cy, r, width) {
   return element('circle', attr)
 }
 
-var rect = function (cx, cy, r, width, height) {
+var rect = function(cx, cy, r, width, height) {
   var attr = {
     x: shift(cx - width / 2),
     y: shift(cy - height / 2),
     width: shift(width),
-    height: shift(height)
+    height: shift(height),
   }
 
   if (r) {
@@ -41,9 +41,9 @@ var rect = function (cx, cy, r, width, height) {
   return element('rect', attr)
 }
 
-var poly = function (points) {
+var poly = function(points) {
   var pointsAttr = points
-    .map(function (point) {
+    .map(function(point) {
       return point.map(shift).join(',')
     })
     .join(' ')
@@ -51,17 +51,17 @@ var poly = function (points) {
   return element('polygon', {points: pointsAttr})
 }
 
-var clip = function (maskIdPrefix, index, shapes, ring, createElement) {
+var clip = function(maskIdPrefix, index, shapes, ring, createElement) {
   var maskId = maskIdPrefix + 'mask-' + index
   var maskUrl = 'url(#' + maskId + ')'
 
   var circleNode = circle(ring.cx, ring.cy, ring.r, ring.width)
 
   var mask = createElement('mask', {id: maskId, stroke: '#fff'}, [
-    createElement(circleNode.tag, circleNode.attr)
+    createElement(circleNode.tag, circleNode.attr),
   ])
 
-  var groupChildren = shapes.map(function (shape) {
+  var groupChildren = shapes.map(function(shape) {
     var node =
       shape.type === 'rect'
         ? rect(shape.cx, shape.cy, shape.r, shape.width, shape.height)
@@ -75,7 +75,7 @@ var clip = function (maskIdPrefix, index, shapes, ring, createElement) {
   return {mask: mask, layer: layer}
 }
 
-module.exports = function reduceShapeArray (
+module.exports = function reduceShapeArray(
   prefix,
   code,
   shapeArray,
@@ -85,7 +85,7 @@ module.exports = function reduceShapeArray (
   var maskIdPrefix = id + '_'
 
   var image = shapeArray.reduce(
-    function (result, shape, index) {
+    function(result, shape, index) {
       var svg
 
       switch (shape.type) {
@@ -130,7 +130,7 @@ module.exports = function reduceShapeArray (
             result.maskBox = shape.box.slice(0)
             result.maskChildren = []
             result.layers = [
-              maskLayer(nextMaskId, result.layers, createElement)
+              maskLayer(nextMaskId, result.layers, createElement),
             ]
           } else {
             var mask = createMask(
@@ -168,7 +168,7 @@ module.exports = function reduceShapeArray (
       maskId: '',
       maskBox: [],
       maskChildren: [],
-      masks: []
+      masks: [],
     }
   )
 

--- a/packages/gerber-to-svg/lib/_util.js
+++ b/packages/gerber-to-svg/lib/_util.js
@@ -3,27 +3,27 @@
 
 // shift the decimal place to SVG coordinates (units * 1000)
 // also round to 7 decimal places
-var shift = function (number) {
+var shift = function(number) {
   return Math.round(10000000000 * number) / 10000000
 }
 
-var boundingRect = function (box, fill, element) {
+var boundingRect = function(box, fill, element) {
   return element('rect', {
     x: shift(box[0]),
     y: shift(box[1]),
     width: shift(box[2] - box[0]),
     height: shift(box[3] - box[1]),
-    fill: fill
+    fill: fill,
   })
 }
 
-var maskLayer = function (maskId, layer, element) {
+var maskLayer = function(maskId, layer, element) {
   var maskUrl = 'url(#' + maskId + ')'
 
   return element('g', {mask: maskUrl}, layer)
 }
 
-var createMask = function (maskId, box, children, element) {
+var createMask = function(maskId, box, children, element) {
   children = [boundingRect(box, '#fff', element)].concat(children)
   var attributes = {id: maskId, fill: '#000', stroke: '#000'}
 
@@ -33,5 +33,5 @@ var createMask = function (maskId, box, children, element) {
 module.exports = {
   shift: shift,
   maskLayer: maskLayer,
-  createMask: createMask
+  createMask: createMask,
 }

--- a/packages/gerber-to-svg/lib/clone.js
+++ b/packages/gerber-to-svg/lib/clone.js
@@ -3,8 +3,8 @@
 
 var KEYS = ['defs', 'layer', 'viewBox', 'width', 'height', 'units']
 
-module.exports = function cloneConverter (converter) {
-  return KEYS.reduce(function (result, key) {
+module.exports = function cloneConverter(converter) {
+  return KEYS.reduce(function(result, key) {
     var value = converter[key]
 
     if (value != null) {

--- a/packages/gerber-to-svg/lib/gerber-to-svg.js
+++ b/packages/gerber-to-svg/lib/gerber-to-svg.js
@@ -12,7 +12,7 @@ var PlotterToSvg = require('./plotter-to-svg')
 var render = require('./render')
 var clone = require('./clone')
 
-var getAttributesFromOptions = function (options) {
+var getAttributesFromOptions = function(options) {
   if (!options) {
     return {}
   }
@@ -28,7 +28,7 @@ var getAttributesFromOptions = function (options) {
   return attributes
 }
 
-var parseOptions = function (options) {
+var parseOptions = function(options) {
   var attributes = getAttributesFromOptions(options)
 
   if (!attributes.id) {
@@ -41,12 +41,12 @@ var parseOptions = function (options) {
       createElement: options.createElement || xmlElementString,
       includeNamespace:
         options.includeNamespace == null ? true : options.includeNamespace,
-      objectMode: options.objectMode == null ? false : options.objectMode
+      objectMode: options.objectMode == null ? false : options.objectMode,
     },
     parser: {
       places: options.places,
       zero: options.zero,
-      filetype: options.filetype
+      filetype: options.filetype,
     },
     plotter: {
       units: options.units,
@@ -54,14 +54,14 @@ var parseOptions = function (options) {
       nota: options.nota,
       backupNota: options.backupNota,
       optimizePaths: options.optimizePaths,
-      plotAsOutline: options.plotAsOutline
-    }
+      plotAsOutline: options.plotAsOutline,
+    },
   }
 
   return opts
 }
 
-module.exports = function gerberConverterFactory (gerber, options, done) {
+module.exports = function gerberConverterFactory(gerber, options, done) {
   var opts = parseOptions(options)
   var callbackMode = done != null
 
@@ -78,21 +78,21 @@ module.exports = function gerberConverterFactory (gerber, options, done) {
   converter.parser = parser
   converter.plotter = plotter
 
-  parser.on('warning', function handleParserWarning (w) {
+  parser.on('warning', function handleParserWarning(w) {
     converter.emit('warning', w)
   })
-  plotter.on('warning', function handlePlotterWarning (w) {
+  plotter.on('warning', function handlePlotterWarning(w) {
     converter.emit('warning', w)
   })
-  parser.once('error', function handleParserError (e) {
+  parser.once('error', function handleParserError(e) {
     converter.emit('error', e)
   })
-  plotter.once('error', function handlePlotterError (e) {
+  plotter.once('error', function handlePlotterError(e) {
     converter.emit('error', e)
   })
 
   // expose the filetype property of the parser for convenience
-  parser.once('end', function () {
+  parser.once('end', function() {
     converter.filetype = parser.format.filetype
   })
 
@@ -101,7 +101,7 @@ module.exports = function gerberConverterFactory (gerber, options, done) {
     gerber.pipe(parser)
   } else {
     // write the gerber string after listeners have been attached etc
-    process.nextTick(function writeStringToParser () {
+    process.nextTick(function writeStringToParser() {
       parser.write(gerber)
       parser.end()
     })
@@ -113,11 +113,11 @@ module.exports = function gerberConverterFactory (gerber, options, done) {
   if (callbackMode) {
     var result = ''
 
-    var finishConversion = function () {
+    var finishConversion = function() {
       return done(null, result)
     }
 
-    converter.on('readable', function collectStreamData () {
+    converter.on('readable', function collectStreamData() {
       var data
 
       do {
@@ -128,7 +128,7 @@ module.exports = function gerberConverterFactory (gerber, options, done) {
 
     converter.once('end', finishConversion)
 
-    converter.once('error', function (error) {
+    converter.once('error', function(error) {
       converter.removeListener('end', finishConversion)
 
       return done(error)

--- a/packages/gerber-to-svg/lib/plotter-to-svg.js
+++ b/packages/gerber-to-svg/lib/plotter-to-svg.js
@@ -19,7 +19,7 @@ var BLOCK_MODE_OFF = 0
 var BLOCK_MODE_DARK = 1
 var BLOCK_MODE_CLEAR = 2
 
-var PlotterToSvg = function (
+var PlotterToSvg = function(
   attributes,
   createElement,
   includeNamespace,
@@ -27,7 +27,7 @@ var PlotterToSvg = function (
 ) {
   Transform.call(this, {
     writableObjectMode: true,
-    readableObjectMode: objectMode
+    readableObjectMode: objectMode,
   })
 
   this.defs = []
@@ -59,7 +59,7 @@ var PlotterToSvg = function (
 
 inherits(PlotterToSvg, Transform)
 
-PlotterToSvg.prototype._transform = function (chunk, encoding, done) {
+PlotterToSvg.prototype._transform = function(chunk, encoding, done) {
   switch (chunk.type) {
     case 'shape':
       this.defs = this.defs.concat(
@@ -97,7 +97,7 @@ PlotterToSvg.prototype._transform = function (chunk, encoding, done) {
   done()
 }
 
-PlotterToSvg.prototype._flush = function (done) {
+PlotterToSvg.prototype._flush = function(done) {
   // shut off step repeat finish any in-progress clear layer and/or repeat
   this._handleNewRepeat([])
 
@@ -110,7 +110,7 @@ PlotterToSvg.prototype._flush = function (done) {
   done()
 }
 
-PlotterToSvg.prototype._finishBlockLayer = function () {
+PlotterToSvg.prototype._finishBlockLayer = function() {
   // if there's a block, wrap it up, give it an id, and repeat it
   if (this._block.length) {
     this._blockLayerCount++
@@ -124,7 +124,7 @@ PlotterToSvg.prototype._finishBlockLayer = function () {
   }
 }
 
-PlotterToSvg.prototype._finishClearLayer = function () {
+PlotterToSvg.prototype._finishClearLayer = function() {
   if (this._maskId) {
     this.defs.push(
       createMask(this._maskId, this._maskBox, this._mask, this._element)
@@ -139,7 +139,7 @@ PlotterToSvg.prototype._finishClearLayer = function () {
   return false
 }
 
-PlotterToSvg.prototype._handleNewPolarity = function (polarity, box) {
+PlotterToSvg.prototype._handleNewPolarity = function(polarity, box) {
   if (this._blockMode) {
     if (this._blockLayerCount === 0 && !this._block.length) {
       this._blockMode = polarity === 'dark' ? BLOCK_MODE_DARK : BLOCK_MODE_CLEAR
@@ -163,7 +163,7 @@ PlotterToSvg.prototype._handleNewPolarity = function (polarity, box) {
   }
 }
 
-PlotterToSvg.prototype._handleNewRepeat = function (offsets, box) {
+PlotterToSvg.prototype._handleNewRepeat = function(offsets, box) {
   var endOfBlock = offsets.length === 0
 
   // finish any in progress clear layer and block layer
@@ -178,13 +178,13 @@ PlotterToSvg.prototype._handleNewRepeat = function (offsets, box) {
   var blockIdStart = this._id + '_block-' + this._blockCount + '-'
 
   // add dark layers to layer
-  this._offsets.forEach(function (offset) {
+  this._offsets.forEach(function(offset) {
     for (var i = blockMode; i <= blockLayers; i += 2) {
       layer.push(
         element('use', {
           'xlink:href': '#' + blockIdStart + i,
           x: shift(offset[0]),
-          y: shift(offset[1])
+          y: shift(offset[1]),
         })
       )
     }
@@ -197,7 +197,7 @@ PlotterToSvg.prototype._handleNewRepeat = function (offsets, box) {
     this.layer = [maskLayer(maskId, layer, this._element)]
     this._maskId = maskId
     this._maskBox = this._blockBox.slice(0)
-    this._mask = this._offsets.reduce(function (result, offset) {
+    this._mask = this._offsets.reduce(function(result, offset) {
       var isDark
 
       for (var i = 1; i <= blockLayers; i++) {
@@ -206,7 +206,7 @@ PlotterToSvg.prototype._handleNewRepeat = function (offsets, box) {
         var attr = {
           'xlink:href': '#' + blockIdStart + i,
           x: shift(offset[0]),
-          y: shift(offset[1])
+          y: shift(offset[1]),
         }
 
         if (isDark) {
@@ -235,7 +235,7 @@ PlotterToSvg.prototype._handleNewRepeat = function (offsets, box) {
   }
 }
 
-PlotterToSvg.prototype._handleSize = function (box, units) {
+PlotterToSvg.prototype._handleSize = function(box, units) {
   if (box.every(isFinite)) {
     var x = shift(box[0])
     var y = shift(box[1])
@@ -249,7 +249,7 @@ PlotterToSvg.prototype._handleSize = function (box, units) {
   }
 }
 
-PlotterToSvg.prototype._draw = function (object) {
+PlotterToSvg.prototype._draw = function(object) {
   if (!this._blockMode) {
     if (!this._maskId) {
       this.layer.push(object)

--- a/packages/gerber-to-svg/lib/render.js
+++ b/packages/gerber-to-svg/lib/render.js
@@ -3,7 +3,7 @@
 
 var xmlElementString = require('xml-element-string')
 
-module.exports = function (converter, attr, createElement, includeNamespace) {
+module.exports = function(converter, attr, createElement, includeNamespace) {
   var element = createElement || xmlElementString
   var namespace =
     includeNamespace == null || includeNamespace === true
@@ -20,10 +20,10 @@ module.exports = function (converter, attr, createElement, includeNamespace) {
     'fill-rule': 'evenodd',
     width: converter.width + converter.units,
     height: converter.height + converter.units,
-    viewBox: converter.viewBox.join(' ')
+    viewBox: converter.viewBox.join(' '),
   }
 
-  Object.keys(attr || {}).forEach(function (key) {
+  Object.keys(attr || {}).forEach(function(key) {
     var value = attr[key]
 
     if (value != null) {
@@ -47,7 +47,7 @@ module.exports = function (converter, attr, createElement, includeNamespace) {
         {
           transform: transform,
           fill: 'currentColor',
-          stroke: 'currentColor'
+          stroke: 'currentColor',
         },
         converter.layer
       )

--- a/packages/gerber-to-svg/test/gerber-to-svg_test.js
+++ b/packages/gerber-to-svg/test/gerber-to-svg_test.js
@@ -20,18 +20,18 @@ var gerberToSvg = proxyquire('../lib/gerber-to-svg', {
   'gerber-parser': parserStub,
   'gerber-plotter': plotterStub,
   'xml-element-string': xmlElementSpy,
-  './plotter-to-svg': converterStub
+  './plotter-to-svg': converterStub,
 })
 
 var render = require('../lib/render')
 var clone = require('../lib/clone')
 
-describe('gerber to svg', function () {
+describe('gerber to svg', function() {
   var fakeParser
   var fakePlotter
   var fakeConverter
 
-  beforeEach(function () {
+  beforeEach(function() {
     parserStub.reset()
     plotterStub.reset()
     converterStub.reset()
@@ -40,18 +40,18 @@ describe('gerber to svg', function () {
     assign(fakeParser, {
       pipe: sinon.stub().returnsArg(0),
       write: sinon.spy(),
-      end: sinon.spy()
+      end: sinon.spy(),
     })
     fakePlotter = new events.EventEmitter()
     assign(fakePlotter, {
       pipe: sinon.stub().returnsArg(0),
-      write: sinon.spy()
+      write: sinon.spy(),
     })
     fakeConverter = new events.EventEmitter()
     assign(fakeConverter, {
       pipe: sinon.stub().returnsArg(0),
       read: sinon.stub(),
-      write: sinon.spy()
+      write: sinon.spy(),
     })
 
     parserStub.returns(fakeParser)
@@ -59,15 +59,15 @@ describe('gerber to svg', function () {
     converterStub.returns(fakeConverter)
   })
 
-  afterEach(function () {
+  afterEach(function() {
     fakeParser.removeAllListeners()
     fakePlotter.removeAllListeners()
     fakeConverter.removeAllListeners()
   })
 
-  it('should return a the converter transform stream', function () {
+  it('should return a the converter transform stream', function() {
     var converter1 = gerberToSvg('', 'test-id')
-    var converter2 = gerberToSvg('', 'test-id', function () {})
+    var converter2 = gerberToSvg('', 'test-id', function() {})
 
     expect(converter1).to.equal(fakeConverter)
     expect(converter2).to.equal(fakeConverter)
@@ -76,8 +76,8 @@ describe('gerber to svg', function () {
     expect(converterStub).to.have.callCount(2)
   })
 
-  it('should gather readable data from the converter in callback mode', function (done) {
-    gerberToSvg('foobar*\n', 'quz', function (error, result) {
+  it('should gather readable data from the converter in callback mode', function(done) {
+    gerberToSvg('foobar*\n', 'quz', function(error, result) {
       expect(error == null).to.equal(true)
       expect(result).to.equal('<svg><foo/><bar/></svg>')
       done()
@@ -95,7 +95,7 @@ describe('gerber to svg', function () {
     fakeConverter.emit('end')
   })
 
-  it('should pipe a stream input into the parser and listen for errors', function () {
+  it('should pipe a stream input into the parser and listen for errors', function() {
     var input = {pipe: sinon.spy(), setEncoding: sinon.spy()}
 
     gerberToSvg(input, 'test-id')
@@ -105,44 +105,44 @@ describe('gerber to svg', function () {
     expect(input.setEncoding).to.be.calledWith('utf8')
   })
 
-  it('should write string input into the parser', function (done) {
+  it('should write string input into the parser', function(done) {
     var input = 'G04 empty gerber*\nM02*\n'
 
     gerberToSvg(input, 'test-id')
 
-    setTimeout(function () {
+    setTimeout(function() {
       expect(fakeParser.write).to.be.calledWith(input)
       expect(fakeParser.end).to.have.callCount(1)
       done()
     }, 10)
   })
 
-  it('should pass the id to plotter-to-svg when it is a string', function () {
+  it('should pass the id to plotter-to-svg when it is a string', function() {
     gerberToSvg('', 'foo')
     expect(converterStub).to.be.calledWith({id: 'foo'})
   })
 
-  it('should pass the id in an object', function () {
+  it('should pass the id in an object', function() {
     gerberToSvg('', {id: 'bar'})
     expect(converterStub).to.be.calledWith({id: 'bar'})
   })
 
-  it('should throw an error if id is missing', function () {
-    expect(function () {
+  it('should throw an error if id is missing', function() {
+    expect(function() {
       gerberToSvg('', {})
     }).to.throw(/id required/)
-    expect(function () {
+    expect(function() {
       gerberToSvg('')
     }).to.throw(/id required/)
   })
 
-  it('should pass the attributes option', function () {
+  it('should pass the attributes option', function() {
     gerberToSvg('', {id: 'foo', attributes: {bar: 'baz'}})
     expect(converterStub).to.be.calledWith({id: 'foo', bar: 'baz'})
   })
 
-  it('should pass createElement, which should default to xml-element-string', function () {
-    var element = function () {}
+  it('should pass createElement, which should default to xml-element-string', function() {
+    var element = function() {}
 
     gerberToSvg('', {id: 'foo'})
     expect(converterStub).to.be.calledWith({id: 'foo'}, xmlElementSpy)
@@ -150,21 +150,21 @@ describe('gerber to svg', function () {
     expect(converterStub).to.be.calledWith({id: 'bar'}, element)
   })
 
-  it('should pass includeNamespace, which should default true', function () {
-    var element = function () {}
+  it('should pass includeNamespace, which should default true', function() {
+    var element = function() {}
 
     gerberToSvg('', {id: 'foo', createElement: element})
     expect(converterStub).to.be.calledWith({id: 'foo'}, element, true)
     gerberToSvg('', {
       id: 'bar',
       createElement: element,
-      includeNamespace: false
+      includeNamespace: false,
     })
     expect(converterStub).to.be.calledWith({id: 'bar'}, element, false)
   })
 
-  it('should pass objectMode, which should default to false', function () {
-    var element = function () {}
+  it('should pass objectMode, which should default to false', function() {
+    var element = function() {}
 
     gerberToSvg('', {id: 'foo', createElement: element})
     expect(converterStub).to.be.calledWith({id: 'foo'}, element, true, false)
@@ -172,23 +172,23 @@ describe('gerber to svg', function () {
     expect(converterStub).to.be.calledWith({id: 'bar'}, element, true, true)
   })
 
-  describe('passing along warnings', function () {
-    it('should emit warnings from the parser', function (done) {
+  describe('passing along warnings', function() {
+    it('should emit warnings from the parser', function(done) {
       var converter = gerberToSvg('foobar*\n', 'foobar')
       var warning = {}
 
-      converter.once('warning', function (w) {
+      converter.once('warning', function(w) {
         expect(w).to.equal(warning)
         done()
       })
       fakeParser.emit('warning', warning)
     })
 
-    it('should emit warnings from the plotter', function (done) {
+    it('should emit warnings from the plotter', function(done) {
       var converter = gerberToSvg('foobar*\n', 'foobar')
       var warning = {}
 
-      converter.once('warning', function (w) {
+      converter.once('warning', function(w) {
         expect(w).to.equal(warning)
         done()
       })
@@ -196,33 +196,33 @@ describe('gerber to svg', function () {
     })
   })
 
-  describe('passing along errors', function () {
-    it('should emit errors from the parser', function (done) {
+  describe('passing along errors', function() {
+    it('should emit errors from the parser', function(done) {
       var converter = gerberToSvg('foobar*\n', 'foobar')
       var error = {}
 
-      converter.once('error', function (e) {
+      converter.once('error', function(e) {
         expect(e).to.equal(error)
         done()
       })
       fakeParser.emit('error', error)
     })
 
-    it('should emit errors from the plotter', function (done) {
+    it('should emit errors from the plotter', function(done) {
       var converter = gerberToSvg('foobar*\n', 'foobar')
       var error = {}
 
-      converter.once('error', function (e) {
+      converter.once('error', function(e) {
         expect(e).to.equal(error)
         done()
       })
       fakePlotter.emit('error', error)
     })
 
-    it('should return errors from the parser in callback mode', function (done) {
+    it('should return errors from the parser in callback mode', function(done) {
       var expectedError = {}
 
-      gerberToSvg('foobar*\n', 'foobar', function (error) {
+      gerberToSvg('foobar*\n', 'foobar', function(error) {
         expect(error).to.equal(expectedError)
         done()
       })
@@ -230,10 +230,10 @@ describe('gerber to svg', function () {
       fakeParser.emit('error', expectedError)
     })
 
-    it('should return errors from the plotter in callback mode', function (done) {
+    it('should return errors from the plotter in callback mode', function(done) {
       var expectedError = {}
 
-      gerberToSvg('foobar*\n', 'foobar', function (error) {
+      gerberToSvg('foobar*\n', 'foobar', function(error) {
         expect(error).to.equal(expectedError)
         done()
       })
@@ -242,7 +242,7 @@ describe('gerber to svg', function () {
     })
   })
 
-  it('should take the filetype format from the parser', function () {
+  it('should take the filetype format from the parser', function() {
     var parser = new events.EventEmitter()
 
     assign(parser, fakeParser, {format: {filetype: 'foobar'}})
@@ -256,14 +256,14 @@ describe('gerber to svg', function () {
     expect(converter.filetype).to.equal('foobar')
   })
 
-  it('should expose the render function used by the converter', function () {
+  it('should expose the render function used by the converter', function() {
     var fakeConverter = {
       defs: ['the'],
       layer: ['other'],
       viewBox: [0, 1, 2, 3],
       width: 'I',
       height: 'must',
-      units: 'have'
+      units: 'have',
     }
     var expected = render(fakeConverter)
 
@@ -271,7 +271,7 @@ describe('gerber to svg', function () {
     expect(gerberToSvg.render(fakeConverter)).to.equal(expected)
   })
 
-  it('shoud have a clone method that clones public properties of a converter', function () {
+  it('shoud have a clone method that clones public properties of a converter', function() {
     var converter = {
       parser: 'hello',
       plotter: 'from',
@@ -284,7 +284,7 @@ describe('gerber to svg', function () {
       _foo: 'called',
       _bar: 'a',
       _baz: 'thousand',
-      _qux: 'times'
+      _qux: 'times',
     }
 
     expect(String(gerberToSvg.clone)).to.equal(String(clone))
@@ -294,28 +294,28 @@ describe('gerber to svg', function () {
       viewBox: 'side',
       width: 'I',
       height: 'must',
-      units: 'have'
+      units: 'have',
     })
   })
 
-  describe('parser and plotter options', function () {
-    it('should pass parser options to the parser', function () {
+  describe('parser and plotter options', function() {
+    it('should pass parser options to the parser', function() {
       var options = {
         id: 'bar',
         places: [2, 3],
         zero: 'T',
-        filetype: 'drill'
+        filetype: 'drill',
       }
 
       gerberToSvg('foo*\n', options)
       expect(parserStub).to.be.calledWith({
         places: [2, 3],
         zero: 'T',
-        filetype: 'drill'
+        filetype: 'drill',
       })
     })
 
-    it('should pass plotter options to the plotter', function () {
+    it('should pass plotter options to the plotter', function() {
       var options = {
         id: 'bar',
         units: 'in',
@@ -323,7 +323,7 @@ describe('gerber to svg', function () {
         nota: 'A',
         backupNota: 'I',
         optimizePaths: true,
-        plotAsOutline: false
+        plotAsOutline: false,
       }
 
       gerberToSvg('foo*\n', options)
@@ -333,11 +333,11 @@ describe('gerber to svg', function () {
         nota: 'A',
         backupNota: 'I',
         optimizePaths: true,
-        plotAsOutline: false
+        plotAsOutline: false,
       })
     })
 
-    it('should include the parser and plotter as properties', function () {
+    it('should include the parser and plotter as properties', function() {
       var result = gerberToSvg('thing', 'id')
 
       expect(result.parser).to.equal(fakeParser)

--- a/packages/gerber-to-svg/test/plotter-to-svg_test.js
+++ b/packages/gerber-to-svg/test/plotter-to-svg_test.js
@@ -25,23 +25,23 @@ var SVG_ATTR = {
   'fill-rule': 'evenodd',
   width: '0',
   height: '0',
-  viewBox: '0 0 0 0'
+  viewBox: '0 0 0 0',
 }
 
 var EMPTY_BOX = [Infinity, Infinity, -Infinity, -Infinity]
 
-describe('plotter to svg transform stream', function () {
+describe('plotter to svg transform stream', function() {
   var p
   var element
 
-  beforeEach(function () {
+  beforeEach(function() {
     element = sinon.spy(xmlElement)
     p = new PlotterToSvg({id: 'id'}, element)
     p.setEncoding('utf8')
   })
 
-  it('should emit an empty svg if it gets a zero size plot', function (done) {
-    p.once('data', function () {
+  it('should emit an empty svg if it gets a zero size plot', function(done) {
+    p.once('data', function() {
       expect(element).to.be.calledWith('svg', SVG_ATTR, [])
       expect(p.viewBox).to.eql([0, 0, 0, 0])
       expect(p.width).to.equal(0)
@@ -54,11 +54,11 @@ describe('plotter to svg transform stream', function () {
     p.end()
   })
 
-  it('should be able to add an id', function (done) {
+  it('should be able to add an id', function(done) {
     var converter = new PlotterToSvg({id: 'foo'}, element)
     var expected = assign({}, SVG_ATTR, {id: 'foo'})
 
-    converter.once('data', function () {
+    converter.once('data', function() {
       expect(element).to.be.calledWith('svg', expected)
       done()
     })
@@ -67,11 +67,11 @@ describe('plotter to svg transform stream', function () {
     converter.end()
   })
 
-  it('should be able to add other attributes', function (done) {
+  it('should be able to add other attributes', function(done) {
     var converter = new PlotterToSvg({id: 'foo', bar: 'baz'}, element)
     var expected = assign({}, SVG_ATTR, {id: 'foo', bar: 'baz'})
 
-    converter.once('data', function () {
+    converter.once('data', function() {
       expect(element).to.be.calledWith('svg', expected)
       done()
     })
@@ -80,9 +80,9 @@ describe('plotter to svg transform stream', function () {
     converter.end()
   })
 
-  it('should be able to omit the namespace from attributes', function (done) {
+  it('should be able to omit the namespace from attributes', function(done) {
     p = new PlotterToSvg({id: 'id'}, element, false)
-    p.once('data', function () {
+    p.once('data', function() {
       expect(element.firstCall.args[1].xmlns == null).to.equal(true)
       done()
     })
@@ -91,8 +91,8 @@ describe('plotter to svg transform stream', function () {
     p.end()
   })
 
-  describe('creating pad shapes', function () {
-    it('should handle circle primitives', function () {
+  describe('creating pad shapes', function() {
+    it('should handle circle primitives', function() {
       var toolShape = [{type: 'circle', cx: 0.001, cy: 0.002, r: 0.005}]
       var expected = {id: 'id_pad-10', cx: 1, cy: 2, r: 5}
 
@@ -101,7 +101,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.defs).to.eql([element.returnValues[0]])
     })
 
-    it('should handle rect primitives', function () {
+    it('should handle rect primitives', function() {
       var toolShape = [
         {
           type: 'rect',
@@ -109,8 +109,8 @@ describe('plotter to svg transform stream', function () {
           cy: 0.004,
           width: 0.002,
           height: 0.004,
-          r: 0.002
-        }
+          r: 0.002,
+        },
       ]
       var expected = {
         id: 'id_pad-10',
@@ -119,7 +119,7 @@ describe('plotter to svg transform stream', function () {
         rx: 2,
         ry: 2,
         width: 2,
-        height: 4
+        height: 4,
       }
 
       p.write({type: 'shape', tool: '10', shape: toolShape})
@@ -127,7 +127,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.defs).to.eql([element.returnValues[0]])
     })
 
-    it('should handle polygon primitives', function () {
+    it('should handle polygon primitives', function() {
       var toolShape = [{type: 'poly', points: [[0, 0], [1, 0], [0, 1]]}]
       var expected = {id: 'id_pad-12', points: '0,0 1000,0 0,1000'}
 
@@ -136,9 +136,9 @@ describe('plotter to svg transform stream', function () {
       expect(p.defs).to.eql([element.returnValues[0]])
     })
 
-    it('should handle a ring primitives', function () {
+    it('should handle a ring primitives', function() {
       var toolShape = [
-        {type: 'ring', r: 0.02, width: 0.005, cx: 0.05, cy: -0.03}
+        {type: 'ring', r: 0.02, width: 0.005, cx: 0.05, cy: -0.03},
       ]
       var expected = {
         id: 'id_pad-11',
@@ -146,7 +146,7 @@ describe('plotter to svg transform stream', function () {
         cy: -30,
         r: 20,
         'stroke-width': 5,
-        fill: 'none'
+        fill: 'none',
       }
 
       p.write({type: 'shape', tool: '11', shape: toolShape})
@@ -154,7 +154,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.defs).to.eql([element.returnValues[0]])
     })
 
-    it('should handle a clipped primitive with rects', function () {
+    it('should handle a clipped primitive with rects', function() {
       var clippedShapes = [
         {type: 'rect', cx: 0.003, cy: 0.003, width: 0.004, height: 0.004, r: 0},
         {
@@ -163,7 +163,7 @@ describe('plotter to svg transform stream', function () {
           cy: 0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -171,7 +171,7 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -179,8 +179,8 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
-        }
+          r: 0,
+        },
       ]
 
       var ring = {type: 'ring', r: 0.004, width: 0.002, cx: 0, cy: 0}
@@ -192,13 +192,13 @@ describe('plotter to svg transform stream', function () {
         {x: -5, y: 1, width: 4, height: 4},
         {x: -5, y: -5, width: 4, height: 4},
         {x: 1, y: -5, width: 4, height: 4},
-        {id: 'id_pad-15', mask: 'url(#id_pad-15_mask-0)'}
+        {id: 'id_pad-15', mask: 'url(#id_pad-15_mask-0)'},
       ]
 
       p.write({type: 'shape', tool: '15', shape: toolShape})
       expect(element).to.be.calledWith('circle', expected[0])
       expect(element).to.be.calledWith('mask', expected[1], [
-        element.returnValues[0]
+        element.returnValues[0],
       ])
       expect(element).to.be.calledWith('rect', expected[2])
       expect(element).to.be.calledWith('rect', expected[3])
@@ -212,7 +212,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.defs).to.eql([element.returnValues[1], element.returnValues[6]])
     })
 
-    it('should handle a clipped primitive with polys', function () {
+    it('should handle a clipped primitive with polys', function() {
       var po = 0.001
       var ne = -0.005
       var mP = po + 0.004
@@ -222,7 +222,7 @@ describe('plotter to svg transform stream', function () {
         {type: 'poly', points: [[po, po], [mP, po], [mP, mP], [po, mP]]},
         {type: 'poly', points: [[ne, po], [mN, po], [mN, mP], [ne, mP]]},
         {type: 'poly', points: [[ne, ne], [mN, ne], [mN, mN], [ne, mN]]},
-        {type: 'poly', points: [[po, ne], [mP, ne], [mP, mN], [po, mN]]}
+        {type: 'poly', points: [[po, ne], [mP, ne], [mP, mN], [po, mN]]},
       ]
       var ring = {type: 'ring', r: 0.004, width: 0.002, cx: 0, cy: 0}
       var toolShape = [{type: 'clip', shape: clippedShapes, clip: ring}]
@@ -233,13 +233,13 @@ describe('plotter to svg transform stream', function () {
         {points: '-5,1 -1,1 -1,5 -5,5'},
         {points: '-5,-5 -1,-5 -1,-1 -5,-1'},
         {points: '1,-5 5,-5 5,-1 1,-1'},
-        {id: 'id_pad-15', mask: 'url(#id_pad-15_mask-0)'}
+        {id: 'id_pad-15', mask: 'url(#id_pad-15_mask-0)'},
       ]
 
       p.write({type: 'shape', tool: '15', shape: toolShape})
       expect(element).to.be.calledWith('circle', expected[0])
       expect(element).to.be.calledWith('mask', expected[1], [
-        element.returnValues[0]
+        element.returnValues[0],
       ])
       expect(element).to.be.calledWith('polygon', expected[2])
       expect(element).to.be.calledWith('polygon', expected[3])
@@ -253,7 +253,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.defs).to.eql([element.returnValues[1], element.returnValues[6]])
     })
 
-    it('should handle multiple primitives', function () {
+    it('should handle multiple primitives', function() {
       var toolShape = [
         {type: 'rect', cx: 0.003, cy: 0.003, width: 0.004, height: 0.004, r: 0},
         {
@@ -262,7 +262,7 @@ describe('plotter to svg transform stream', function () {
           cy: 0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -270,7 +270,7 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -278,8 +278,8 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
-        }
+          r: 0,
+        },
       ]
 
       var expected = [
@@ -287,7 +287,7 @@ describe('plotter to svg transform stream', function () {
         {x: -5, y: 1, width: 4, height: 4},
         {x: -5, y: -5, width: 4, height: 4},
         {x: 1, y: -5, width: 4, height: 4},
-        {id: 'id_pad-20'}
+        {id: 'id_pad-20'},
       ]
 
       p.write({type: 'shape', tool: '20', shape: toolShape})
@@ -303,7 +303,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.defs).to.eql([element.returnValues[4]])
     })
 
-    it('should handle multiple clipped primitives', function () {
+    it('should handle multiple clipped primitives', function() {
       var clippedShapes1 = [
         {type: 'rect', cx: 0.003, cy: 0.003, width: 0.004, height: 0.004, r: 0},
         {
@@ -312,7 +312,7 @@ describe('plotter to svg transform stream', function () {
           cy: 0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -320,7 +320,7 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -328,8 +328,8 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.004,
           height: 0.004,
-          r: 0
-        }
+          r: 0,
+        },
       ]
 
       var clippedShapes2 = [
@@ -340,7 +340,7 @@ describe('plotter to svg transform stream', function () {
           cy: 0.003,
           width: 0.002,
           height: 0.002,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -348,7 +348,7 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.002,
           height: 0.002,
-          r: 0
+          r: 0,
         },
         {
           type: 'rect',
@@ -356,15 +356,15 @@ describe('plotter to svg transform stream', function () {
           cy: -0.003,
           width: 0.002,
           height: 0.002,
-          r: 0
-        }
+          r: 0,
+        },
       ]
 
       var ring1 = {type: 'ring', r: 0.004, width: 0.002, cx: 0, cy: 0}
       var ring2 = {type: 'ring', r: 0.002, width: 0.001, cx: 0, cy: 0}
       var toolShape = [
         {type: 'clip', shape: clippedShapes1, clip: ring1},
-        {type: 'clip', shape: clippedShapes2, clip: ring2}
+        {type: 'clip', shape: clippedShapes2, clip: ring2},
       ]
 
       p.write({type: 'shape', tool: '15', shape: toolShape})
@@ -385,7 +385,7 @@ describe('plotter to svg transform stream', function () {
         {x: -4, y: -4, width: 2, height: 2},
         {x: 2, y: -4, width: 2, height: 2},
         {mask: 'url(#id_pad-15_mask-1)'},
-        {id: 'id_pad-15'}
+        {id: 'id_pad-15'},
       ]
 
       expect(element).to.be.calledWith('circle', expected[0])
@@ -404,12 +404,12 @@ describe('plotter to svg transform stream', function () {
       expect(element).to.be.calledWith('g', expected[13], values.slice(9, 13))
       expect(element).to.be.calledWith('g', expected[14], [
         values[6],
-        values[13]
+        values[13],
       ])
       expect(p.defs).to.eql([values[1], values[8], values[14]])
     })
 
-    it('should handle polarity changes', function () {
+    it('should handle polarity changes', function() {
       var toolShape = [
         {type: 'rect', cx: 0, cy: 0.005, width: 0.006, height: 0.008, r: 0},
         {type: 'layer', polarity: 'clear', box: [-0.003, 0.001, 0.003, 0.009]},
@@ -419,7 +419,7 @@ describe('plotter to svg transform stream', function () {
         {type: 'circle', cx: 0, cy: 0, r: 0.004},
         {type: 'layer', polarity: 'clear', box: [-0.004, -0.009, 0.004, 0.004]},
         {type: 'rect', cx: 0, cy: -0.005, width: 0.004, height: 0.004, r: 0},
-        {type: 'circle', cx: 0, cy: 0, r: 0.002}
+        {type: 'circle', cx: 0, cy: 0, r: 0.002},
       ]
 
       var expected = [
@@ -435,7 +435,7 @@ describe('plotter to svg transform stream', function () {
         {cx: 0, cy: 0, r: 2},
         {x: -4, y: -9, width: 8, height: 13, fill: '#fff'},
         {id: 'id_pad-11_3', fill: '#000', stroke: '#000'},
-        {id: 'id_pad-11'}
+        {id: 'id_pad-11'},
       ]
 
       p.write({type: 'shape', tool: '11', shape: toolShape})
@@ -448,14 +448,14 @@ describe('plotter to svg transform stream', function () {
       expect(element).to.be.calledWith('rect', expected[3])
       expect(element).to.be.calledWith('mask', expected[4], [
         values[3],
-        values[2]
+        values[2],
       ])
       expect(element).to.be.calledWith('rect', expected[5])
       expect(element).to.be.calledWith('circle', expected[6])
       expect(element).to.be.calledWith('g', expected[7], [
         values[1],
         values[5],
-        values[6]
+        values[6],
       ])
       expect(element).to.be.calledWith('rect', expected[8])
       expect(element).to.be.calledWith('circle', expected[9])
@@ -463,27 +463,27 @@ describe('plotter to svg transform stream', function () {
       expect(element).to.be.calledWith('mask', expected[11], [
         values[10],
         values[8],
-        values[9]
+        values[9],
       ])
       expect(element).to.be.calledWith('g', expected[12], [values[7]])
       expect(p.defs).to.eql([values[4], values[11], values[12]])
     })
   })
 
-  it('should be able to add a pad to the layer', function () {
+  it('should be able to add a pad to the layer', function() {
     var pad = {type: 'pad', tool: '24', x: 0.02, y: 0.05}
 
     p.write(pad)
     expect(element).to.be.calledWith('use', {
       'xlink:href': '#id_pad-24',
       x: 20,
-      y: 50
+      y: 50,
     })
     expect(p.layer).to.eql(element.returnValues)
   })
 
-  describe('fills and strokes', function () {
-    it('should add a path to the layer for a fill', function () {
+  describe('fills and strokes', function() {
+    it('should add a path to the layer for a fill', function() {
       var fill = {type: 'fill', path: []}
 
       p.write(fill)
@@ -491,30 +491,30 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should add a path with width and no fill for a stroke', function () {
+    it('should add a path with width and no fill for a stroke', function() {
       var stroke = {type: 'stroke', path: [], width: 0.006}
 
       p.write(stroke)
       expect(element).to.be.calledWith('path', {
         d: '',
         fill: 'none',
-        'stroke-width': 6
+        'stroke-width': 6,
       })
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should know how to add line segments', function () {
+    it('should know how to add line segments', function() {
       var path = [
         {type: 'line', start: [0, 0], end: [0.1, 0]},
         {type: 'line', start: [0.1, 0], end: [0.1, 0.1]},
         {type: 'line', start: [0.1, 0.1], end: [0, 0.1]},
-        {type: 'line', start: [0, 0.1], end: [0, 0]}
+        {type: 'line', start: [0, 0.1], end: [0, 0]},
       ]
       var stroke = {type: 'stroke', width: 0.006, path: path}
       var expected = {
         d: 'M 0 0 100 0 100 100 0 100 0 0',
         fill: 'none',
-        'stroke-width': 6
+        'stroke-width': 6,
       }
 
       p.write(stroke)
@@ -522,17 +522,17 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should know when to add movetos', function () {
+    it('should know when to add movetos', function() {
       var path = [
         {type: 'line', start: [0, 0], end: [0.1, 0.1]},
         {type: 'line', start: [0.2, 0.2], end: [0.3, 0.3]},
-        {type: 'line', start: [0.4, 0.4], end: [0.5, 0.5]}
+        {type: 'line', start: [0.4, 0.4], end: [0.5, 0.5]},
       ]
       var stroke = {type: 'stroke', width: 0.006, path: path}
       var expected = {
         d: 'M 0 0 100 100 M 200 200 300 300 M 400 400 500 500',
         fill: 'none',
-        'stroke-width': 6
+        'stroke-width': 6,
       }
 
       p.write(stroke)
@@ -540,7 +540,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should know how to add arcs', function () {
+    it('should know how to add arcs', function() {
       var path = [
         {
           type: 'arc',
@@ -549,7 +549,7 @@ describe('plotter to svg transform stream', function () {
           center: [0, 0],
           sweep: HALF_PI,
           radius: 0.1,
-          dir: 'ccw'
+          dir: 'ccw',
         },
         {
           type: 'arc',
@@ -558,7 +558,7 @@ describe('plotter to svg transform stream', function () {
           center: [0, 0],
           sweep: 3 * HALF_PI,
           radius: 0.1,
-          dir: 'ccw'
+          dir: 'ccw',
         },
         {
           type: 'arc',
@@ -567,7 +567,7 @@ describe('plotter to svg transform stream', function () {
           center: [1, 0],
           sweep: 3 * HALF_PI,
           radius: 0.1,
-          dir: 'cw'
+          dir: 'cw',
         },
         {
           type: 'arc',
@@ -576,14 +576,14 @@ describe('plotter to svg transform stream', function () {
           center: [1, 0],
           sweep: HALF_PI,
           radius: 0.1,
-          dir: 'cw'
-        }
+          dir: 'cw',
+        },
       ]
 
       var stroke = {type: 'stroke', width: 0.006, path: path}
       var expectedData = [
         'M 100 0 A 100 100 0 0 1 0 100 100 100 0 1 1 100 0',
-        'M 1100 0 A 100 100 0 1 0 1000 100 100 100 0 0 0 1100 0'
+        'M 1100 0 A 100 100 0 1 0 1000 100 100 100 0 0 0 1100 0',
       ].join(' ')
 
       var expected = {d: expectedData, fill: 'none', 'stroke-width': 6}
@@ -593,7 +593,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should add zero-length arcs as linetos', function () {
+    it('should add zero-length arcs as linetos', function() {
       var path = [
         {
           type: 'arc',
@@ -602,8 +602,8 @@ describe('plotter to svg transform stream', function () {
           center: [-1, 0],
           sweep: 0,
           radius: 1,
-          dir: 'ccw'
-        }
+          dir: 'ccw',
+        },
       ]
 
       var stroke = {type: 'stroke', width: 0.006, path: path}
@@ -614,7 +614,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should add full circle arcs as two arcs', function () {
+    it('should add full circle arcs as two arcs', function() {
       var path = [
         {
           type: 'arc',
@@ -623,15 +623,15 @@ describe('plotter to svg transform stream', function () {
           center: [-0.1, 0],
           sweep: 2 * Math.PI,
           radius: 0.1,
-          dir: 'ccw'
-        }
+          dir: 'ccw',
+        },
       ]
 
       var stroke = {type: 'stroke', width: 0.006, path: path}
       var expected = {
         d: 'M 0 0 A 100 100 0 0 1 -200 0 100 100 0 0 1 0 0',
         fill: 'none',
-        'stroke-width': 6
+        'stroke-width': 6,
       }
 
       p.write(stroke)
@@ -639,7 +639,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should only add explicit linetos as needed', function () {
+    it('should only add explicit linetos as needed', function() {
       var path = [
         {
           type: 'arc',
@@ -648,16 +648,16 @@ describe('plotter to svg transform stream', function () {
           center: [0, 0],
           sweep: Math.PI,
           radius: 0.1,
-          dir: 'ccw'
+          dir: 'ccw',
         },
-        {type: 'line', start: [-0.1, 0], end: [0, 0]}
+        {type: 'line', start: [-0.1, 0], end: [0, 0]},
       ]
 
       var stroke = {type: 'stroke', width: 0.006, path: path}
       var expected = {
         d: 'M 100 0 A 100 100 0 0 1 -100 0 L 0 0',
         fill: 'none',
-        'stroke-width': 6
+        'stroke-width': 6,
       }
 
       p.write(stroke)
@@ -666,8 +666,8 @@ describe('plotter to svg transform stream', function () {
     })
   })
 
-  describe('polarity changes', function () {
-    it('should wrap the layer in a masked group when polarity becomes clear', function () {
+  describe('polarity changes', function() {
+    it('should wrap the layer in a masked group when polarity becomes clear', function() {
       var existing = ['<path d="M 0 0 1 0 1 1 0 1 0 0"/>']
       var polarity = {type: 'polarity', polarity: 'clear', box: [0, 0, 1, 1]}
 
@@ -681,7 +681,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues)
     })
 
-    it('should construct a mask and add to defs when polarity switches back', function () {
+    it('should construct a mask and add to defs when polarity switches back', function() {
       var clear = {type: 'polarity', polarity: 'clear', box: [0, 0, 0.5, 0.5]}
       var clearPad = {type: 'pad', tool: '10', x: 0.005, y: 0.005}
       var dark = {type: 'polarity', polarity: 'dark', box: [0, 0, 0.5, 0.5]}
@@ -698,7 +698,7 @@ describe('plotter to svg transform stream', function () {
         {'xlink:href': '#id_pad-10', x: 5, y: 5},
         {x: 0, y: 0, width: 500, height: 500, fill: '#fff'},
         {id: 'id_clear-1', fill: '#000', stroke: '#000'},
-        {'xlink:href': '#id_pad-11', x: 5, y: 5}
+        {'xlink:href': '#id_pad-11', x: 5, y: 5},
       ]
 
       expect(element).to.be.calledWith('g', expected[0], [])
@@ -706,7 +706,7 @@ describe('plotter to svg transform stream', function () {
       expect(element).to.be.calledWith('rect', expected[2])
       expect(element).to.be.calledWith('mask', expected[3], [
         values[2],
-        values[1]
+        values[1],
       ])
       expect(element).to.be.calledWith('use', expected[4])
       expect(p._mask).to.eql([])
@@ -714,7 +714,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql([values[0], values[4]])
     })
 
-    it('should not do anything with dark polarity if there is no mask', function () {
+    it('should not do anything with dark polarity if there is no mask', function() {
       var dark = {type: 'polarity', polarity: 'dark', box: [0, 0, 1, 1]}
 
       p.write(dark)
@@ -725,8 +725,8 @@ describe('plotter to svg transform stream', function () {
     })
   })
 
-  describe('block repeats', function () {
-    it('if only one layer, it should wrap the current layer and repeat it', function () {
+  describe('block repeats', function() {
+    it('if only one layer, it should wrap the current layer and repeat it', function() {
       var offsets = [[0, 0], [0, 1], [1, 0], [1, 1]]
       var expected = [
         {'xlink:href': '#id_pad-10', x: 250, y: 250},
@@ -734,7 +734,7 @@ describe('plotter to svg transform stream', function () {
         {'xlink:href': '#id_block-1-1', x: 0, y: 0},
         {'xlink:href': '#id_block-1-1', x: 0, y: 1000},
         {'xlink:href': '#id_block-1-1', x: 1000, y: 0},
-        {'xlink:href': '#id_block-1-1', x: 1000, y: 1000}
+        {'xlink:href': '#id_block-1-1', x: 1000, y: 1000},
       ]
 
       p.write({type: 'repeat', offsets: offsets, box: [0, 0, 0.5, 0.5]})
@@ -742,7 +742,7 @@ describe('plotter to svg transform stream', function () {
       p.write({type: 'repeat', offsets: [], box: [0, 0, 1.5, 1.5]})
       expect(element).to.be.calledWith('use', expected[0])
       expect(element).to.be.calledWith('g', expected[1], [
-        element.returnValues[0]
+        element.returnValues[0],
       ])
       expect(element).to.be.calledWith('use', expected[2])
       expect(element).to.be.calledWith('use', expected[3])
@@ -752,7 +752,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql(element.returnValues.slice(2, 6))
     })
 
-    it('should allow several layers in a block', function () {
+    it('should allow several layers in a block', function() {
       var offsets = [[0, 0], [0, 5], [5, 0], [5, 5]]
 
       p.write({type: 'repeat', offsets: offsets, box: [0, 0, 0.5, 0.5]})
@@ -797,7 +797,7 @@ describe('plotter to svg transform stream', function () {
           x: 0,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-2', x: 0, y: 0},
         {
@@ -805,7 +805,7 @@ describe('plotter to svg transform stream', function () {
           x: 0,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-4', x: 0, y: 0},
         {
@@ -813,14 +813,14 @@ describe('plotter to svg transform stream', function () {
           x: 0,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {
           'xlink:href': '#id_block-1-1',
           x: 0,
           y: 5000,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-2', x: 0, y: 5000},
         {
@@ -828,7 +828,7 @@ describe('plotter to svg transform stream', function () {
           x: 0,
           y: 5000,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-4', x: 0, y: 5000},
         {
@@ -836,14 +836,14 @@ describe('plotter to svg transform stream', function () {
           x: 0,
           y: 5000,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {
           'xlink:href': '#id_block-1-1',
           x: 5000,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-2', x: 5000, y: 0},
         {
@@ -851,7 +851,7 @@ describe('plotter to svg transform stream', function () {
           x: 5000,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-4', x: 5000, y: 0},
         {
@@ -859,14 +859,14 @@ describe('plotter to svg transform stream', function () {
           x: 5000,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {
           'xlink:href': '#id_block-1-1',
           x: 5000,
           y: 5000,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-2', x: 5000, y: 5000},
         {
@@ -874,7 +874,7 @@ describe('plotter to svg transform stream', function () {
           x: 5000,
           y: 5000,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-4', x: 5000, y: 5000},
         {
@@ -882,10 +882,10 @@ describe('plotter to svg transform stream', function () {
           x: 5000,
           y: 5000,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {x: 0, y: 0, width: 500, height: 500, fill: '#fff'},
-        {id: 'id_block-1-clear', fill: '#000', stroke: '#000'}
+        {id: 'id_block-1-clear', fill: '#000', stroke: '#000'},
       ]
 
       expect(element).to.be.calledWith('use', expected[0])
@@ -944,13 +944,13 @@ describe('plotter to svg transform stream', function () {
         values[5],
         values[7],
         values[9],
-        values[44]
+        values[44],
       ])
 
       expect(p.layer).to.eql([values[22]])
     })
 
-    it('should handle step repeats that start with clear', function () {
+    it('should handle step repeats that start with clear', function() {
       var offsets = [[0, 0], [0, 0.5], [0.5, 0], [0.5, 0.5]]
 
       p.layer = ['LAYER']
@@ -982,7 +982,7 @@ describe('plotter to svg transform stream', function () {
           x: 0,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-1', x: 0, y: 500},
         {
@@ -990,7 +990,7 @@ describe('plotter to svg transform stream', function () {
           x: 0,
           y: 500,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-1', x: 500, y: 0},
         {
@@ -998,7 +998,7 @@ describe('plotter to svg transform stream', function () {
           x: 500,
           y: 0,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {'xlink:href': '#id_block-1-1', x: 500, y: 500},
         {
@@ -1006,10 +1006,10 @@ describe('plotter to svg transform stream', function () {
           x: 500,
           y: 500,
           fill: '#fff',
-          stroke: '#fff'
+          stroke: '#fff',
         },
         {x: 0, y: 0, width: 1000, height: 1000, fill: '#fff'},
-        {id: 'id_block-1-clear', fill: '#000', stroke: '#000'}
+        {id: 'id_block-1-clear', fill: '#000', stroke: '#000'},
       ]
 
       expect(element).to.be.calledWith('g', expected[0])
@@ -1047,7 +1047,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql([values[11]])
     })
 
-    it('should handle step repeats that start with dark then change to clear', function () {
+    it('should handle step repeats that start with dark then change to clear', function() {
       var offsets = [[0, 0], [0, 0.5], [0.5, 0], [0.5, 0.5]]
 
       p.layer = ['SOME_EXISTING_STUFF']
@@ -1066,13 +1066,13 @@ describe('plotter to svg transform stream', function () {
         {'xlink:href': '#id_block-1-1', x: 500, y: 0},
         {'xlink:href': '#id_block-1-1', x: 500, y: 500},
         {x: 0, y: 0, width: 1000, height: 1000, fill: '#fff'},
-        {id: 'id_block-1-clear', fill: '#000', stroke: '#000'}
+        {id: 'id_block-1-clear', fill: '#000', stroke: '#000'},
       ]
 
       expect(element).to.be.calledWith('use', expected[0])
       expect(element).to.be.calledWith('g', expected[1], [values[0]])
       expect(element).to.be.calledWith('g', expected[2], [
-        'SOME_EXISTING_STUFF'
+        'SOME_EXISTING_STUFF',
       ])
       expect(element).to.be.calledWith('use', expected[3])
       expect(element).to.be.calledWith('use', expected[4])
@@ -1088,7 +1088,7 @@ describe('plotter to svg transform stream', function () {
       expect(p.layer).to.eql([values[2]])
     })
 
-    it('should handle polarity switches with no objects gracefully', function () {
+    it('should handle polarity switches with no objects gracefully', function() {
       var offsets = [[0, 0], [0, 0.5], [0.5, 0], [0.5, 0.5]]
 
       p.layer = ['SOME_EXISTING_STUFF']
@@ -1101,7 +1101,7 @@ describe('plotter to svg transform stream', function () {
       expect(element).to.have.callCount(0)
     })
 
-    it('should handle Infinities in the box', function () {
+    it('should handle Infinities in the box', function() {
       var offsets = [[0, 0], [0, 0.5], [0.5, 0], [0.5, 0.5]]
 
       p.layer = ['SOME_EXISTING_STUFF']
@@ -1110,8 +1110,8 @@ describe('plotter to svg transform stream', function () {
     })
   })
 
-  describe('end of stream', function () {
-    it('should create a viewbox from a size object', function () {
+  describe('end of stream', function() {
+    it('should create a viewbox from a size object', function() {
       var size = {type: 'size', box: [-1, -1, 1, 2], units: 'mm'}
 
       p.write(size)
@@ -1121,22 +1121,22 @@ describe('plotter to svg transform stream', function () {
       expect(p.units).to.equal('mm')
     })
 
-    it('should contruct an svg from the layer and defs', function (done) {
+    it('should contruct an svg from the layer and defs', function(done) {
       var size = {type: 'size', box: [-1, -1, 1, 2], units: 'mm'}
       var viewBox = '-1000 -1000 2000 3000'
       var transform = 'translate(0,1000) scale(1,-1)'
       var svgAttr = assign({}, SVG_ATTR, {
         width: '2mm',
         height: '3mm',
-        viewBox: viewBox
+        viewBox: viewBox,
       })
       var layerAttr = {
         transform: transform,
         fill: 'currentColor',
-        stroke: 'currentColor'
+        stroke: 'currentColor',
       }
 
-      p.on('data', function (result) {
+      p.on('data', function(result) {
         expect(element).to.be.calledWith('defs', {}, ['THESE_ARE_THE_DEFS'])
         expect(element).to.be.calledWith('g', layerAttr, ['THIS_IS_THE_LAYER'])
         expect(element).to.be.calledWith(
@@ -1154,10 +1154,10 @@ describe('plotter to svg transform stream', function () {
       p.end()
     })
 
-    it('should omit the defs mode if it is empty', function (done) {
+    it('should omit the defs mode if it is empty', function(done) {
       var size = {type: 'size', box: [-1, -1, 1, 2], units: 'mm'}
 
-      p.on('data', function () {
+      p.on('data', function() {
         expect(element).not.to.be.calledWith('defs')
         done()
       })
@@ -1168,7 +1168,7 @@ describe('plotter to svg transform stream', function () {
       p.end()
     })
 
-    it('should finish any in-progress mask', function () {
+    it('should finish any in-progress mask', function() {
       p._maskId = 'id_clear-1'
       p._maskBox = [1, 2, 3, 4]
       p._mask = ['SOME STUFF']
@@ -1177,11 +1177,11 @@ describe('plotter to svg transform stream', function () {
       expect(element).to.be.calledWith('mask', {
         id: 'id_clear-1',
         fill: '#000',
-        stroke: '#000'
+        stroke: '#000',
       })
     })
 
-    it('should finish any in-progress repeat', function () {
+    it('should finish any in-progress repeat', function() {
       var offsets = [[0, 0], [0, 1], [1, 0], [1, 1]]
 
       p.write({type: 'repeat', offsets: offsets, box: [0, 0, 0.5, 0.5]})
@@ -1191,22 +1191,22 @@ describe('plotter to svg transform stream', function () {
       expect(element).to.be.calledWith('use', {
         'xlink:href': '#id_block-1-1',
         x: 0,
-        y: 0
+        y: 0,
       })
       expect(element).to.be.calledWith('use', {
         'xlink:href': '#id_block-1-1',
         x: 0,
-        y: 1000
+        y: 1000,
       })
       expect(element).to.be.calledWith('use', {
         'xlink:href': '#id_block-1-1',
         x: 1000,
-        y: 0
+        y: 0,
       })
       expect(element).to.be.calledWith('use', {
         'xlink:href': '#id_block-1-1',
         x: 1000,
-        y: 1000
+        y: 1000,
       })
     })
   })

--- a/packages/pcb-stackup-core/example/index.js
+++ b/packages/pcb-stackup-core/example/index.js
@@ -23,7 +23,7 @@ const GERBER_PATHS = [
   'arduino-uno.plc',
   'arduino-uno.sol',
   'arduino-uno.stc',
-  'arduino-uno.sts'
+  'arduino-uno.sts',
 ].map(filename => path.join(GERBERS_DIR, filename))
 
 runWaterfall([renderAllLayers, renderStackupAndWrite], error => {
@@ -32,22 +32,22 @@ runWaterfall([renderAllLayers, renderStackupAndWrite], error => {
   console.log(`Wrote:\n  ${TOP_OUT}\n  ${BOTTOM_OUT}`)
 })
 
-function renderStackupAndWrite (layers, done) {
+function renderStackupAndWrite(layers, done) {
   const options = {
     id: xid.random(),
-    maskWithOutline: true
+    maskWithOutline: true,
   }
 
   const stackup = pcbStackupCore(layers, options)
   const tasks = [
     next => fs.writeFile(TOP_OUT, stackup.top.svg, next),
-    next => fs.writeFile(BOTTOM_OUT, stackup.bottom.svg, next)
+    next => fs.writeFile(BOTTOM_OUT, stackup.bottom.svg, next),
   ]
 
   runParallel(tasks, done)
 }
 
-function renderAllLayers (done) {
+function renderAllLayers(done) {
   const layerTypes = wtg(GERBER_PATHS)
   const tasks = GERBER_PATHS.map(file => next =>
     renderLayer(file, layerTypes, next)
@@ -56,7 +56,7 @@ function renderAllLayers (done) {
   runParallel(tasks, done)
 }
 
-function renderLayer (filename, layerTypes, done) {
+function renderLayer(filename, layerTypes, done) {
   const file = fs.createReadStream(filename)
   const {side, type} = layerTypes[filename]
 
@@ -64,7 +64,7 @@ function renderLayer (filename, layerTypes, done) {
 
   const options = {
     id: xid.random(),
-    plotAsOutline: type === wtg.TYPE_OUTLINE
+    plotAsOutline: type === wtg.TYPE_OUTLINE,
   }
 
   const converter = gerberToSvg(file, options, error => {

--- a/packages/pcb-stackup-core/integration/get-results.js
+++ b/packages/pcb-stackup-core/integration/get-results.js
@@ -10,14 +10,14 @@ const whatsThatGerber = require('whats-that-gerber')
 const debug = require('debug')('tracespace/pcb-stackup-core/integration')
 const pcbStackupCore = require('..')
 
-module.exports = function getStackupResults (board, done) {
+module.exports = function getStackupResults(board, done) {
   debug(`Render started for ${board.name}`)
 
   const {layers} = board
   const options = Object.assign(
     {
       id: `__${board.name}`,
-      maskWithOutline: true
+      maskWithOutline: true,
     },
     board.options
   )
@@ -40,31 +40,31 @@ module.exports = function getStackupResults (board, done) {
         } catch (error) {
           next(error)
         }
-      }
+      },
     ],
     done
   )
 }
 
-function makeBoardResult (board, stackup) {
+function makeBoardResult(board, stackup) {
   return Object.assign(
     {
       specs: [
         {name: 'top', render: stackup.top.svg},
-        {name: 'bottom', render: stackup.bottom.svg}
-      ]
+        {name: 'bottom', render: stackup.bottom.svg},
+      ],
     },
     board
   )
 }
 
-function renderLayer (layer, layerTypes, done) {
+function renderLayer(layer, layerTypes, done) {
   const {filename, name, type: realType, side: realSide} = layer
   const {type, side} = layerTypes[name]
   const options = Object.assign(
     {
       id: `__${filename}`,
-      plotAsOutline: type === whatsThatGerber.TYPE_OUTLINE
+      plotAsOutline: type === whatsThatGerber.TYPE_OUTLINE,
     },
     layer.options
   )

--- a/packages/pcb-stackup-core/integration/pcb-stackup-core-snapshot.test.js
+++ b/packages/pcb-stackup-core/integration/pcb-stackup-core-snapshot.test.js
@@ -10,12 +10,12 @@ const getResults = require('./get-results')
 const SIDES = ['top', 'bottom']
 const BOARDS = getBoards.sync().filter(b => !b.skipSnapshot)
 
-describe(`pcb-stackup-core :: integration`, function () {
+describe(`pcb-stackup-core :: integration`, function() {
   BOARDS.forEach((board, index) =>
-    describe(board.name, function () {
+    describe(board.name, function() {
       let boardResults
 
-      before(function (done) {
+      before(function(done) {
         if (process.env.INTEGRATION !== '1') return this.skip()
 
         getResults(board, (error, results) => {
@@ -26,7 +26,7 @@ describe(`pcb-stackup-core :: integration`, function () {
       })
 
       SIDES.forEach(side =>
-        it(`renders ${side}`, function () {
+        it(`renders ${side}`, function() {
           const result = boardResults.specs.find(s => s.name === side)
           snapshot(format(result.render).split('\n'))
         })

--- a/packages/pcb-stackup-core/lib/_board-style.js
+++ b/packages/pcb-stackup-core/lib/_board-style.js
@@ -2,7 +2,7 @@
 'use strict'
 var colorString = require('color-string')
 
-module.exports = function boardStyle (element, prefix, side, layerColors) {
+module.exports = function boardStyle(element, prefix, side, layerColors) {
   var colors = {
     fr4: '#666',
     cu: '#ccc',
@@ -10,14 +10,14 @@ module.exports = function boardStyle (element, prefix, side, layerColors) {
     sm: 'rgba(00, 66, 00, 0.75)',
     ss: '#fff',
     sp: '#999',
-    out: '#000'
+    out: '#000',
   }
 
-  Object.keys(layerColors || {}).forEach(function (type) {
+  Object.keys(layerColors || {}).forEach(function(type) {
     colors[type] = layerColors[type]
   })
 
-  var colorClass = function (layer) {
+  var colorClass = function(layer) {
     var style = 'color: ' + colors[layer] + ';'
 
     // convert rgba to hex and opacity for inkscape compatibility
@@ -41,7 +41,7 @@ module.exports = function boardStyle (element, prefix, side, layerColors) {
     colorClass('sm'),
     colorClass('ss'),
     colorClass('sp'),
-    colorClass('out')
+    colorClass('out'),
   ]
 
   var stylesString = styles.join('\n')

--- a/packages/pcb-stackup-core/lib/_gather-layers.js
+++ b/packages/pcb-stackup-core/lib/_gather-layers.js
@@ -6,7 +6,7 @@ var wtg = require('whats-that-gerber')
 
 var wrapLayer = require('./wrap-layer')
 
-module.exports = function gatherLayers (
+module.exports = function gatherLayers(
   element,
   idPrefix,
   layers,
@@ -22,7 +22,7 @@ module.exports = function gatherLayers (
   var allLayers = layers.concat(drills, outline || [])
 
   var drillCount = 0
-  var getUniqueId = function (type) {
+  var getUniqueId = function(type) {
     var id = idPrefix + type
 
     if (type === wtg.TYPE_DRILL) {
@@ -33,7 +33,7 @@ module.exports = function gatherLayers (
     return id
   }
 
-  allLayers.forEach(function (layer) {
+  allLayers.forEach(function(layer) {
     if (!layer.externalId) {
       defs = defs.concat(defs, layer.converter.defs)
     }
@@ -50,7 +50,7 @@ module.exports = function gatherLayers (
   }
 
   var viewboxLayers = outline ? [outline] : allLayers
-  var box = viewboxLayers.reduce(function (result, layer) {
+  var box = viewboxLayers.reduce(function(result, layer) {
     var nextBox = layer.converter.viewBox
 
     nextBox = viewbox.scale(nextBox, getScale(units, layer.converter.units))
@@ -58,8 +58,8 @@ module.exports = function gatherLayers (
     return viewbox.add(result, nextBox)
   }, viewbox.create())
 
-  var wrapConverterLayer = function (collection) {
-    return function (layer) {
+  var wrapConverterLayer = function(collection) {
+    return function(layer) {
       var id = layer.externalId
       var converter = layer.converter
 
@@ -104,11 +104,11 @@ module.exports = function gatherLayers (
     units: units,
     layerIds: layerIds,
     drillIds: drillIds,
-    outlineId: outlineId
+    outlineId: outlineId,
   }
 }
 
-function getScale (units, layerUnits) {
+function getScale(units, layerUnits) {
   var scale = units === 'in' ? 1 / 25.4 : 25.4
   var result = units === layerUnits ? 1 : scale
 

--- a/packages/pcb-stackup-core/lib/index.js
+++ b/packages/pcb-stackup-core/lib/index.js
@@ -11,7 +11,7 @@ var boardStyle = require('./_board-style')
 
 var SIDES = [wtg.SIDE_TOP, wtg.SIDE_BOTTOM]
 
-var svgAttributes = function (id, side, box, units, includeNs, attributes) {
+var svgAttributes = function(id, side, box, units, includeNs, attributes) {
   var width = box[2] / 1000 + units
   var height = box[3] / 1000 + units
 
@@ -26,21 +26,21 @@ var svgAttributes = function (id, side, box, units, includeNs, attributes) {
     'clip-rule': 'evenodd',
     viewBox: box.join(' '),
     width: width,
-    height: height
+    height: height,
   }
 
   if (includeNs || includeNs == null) {
     attr.xmlns = 'http://www.w3.org/2000/svg'
   }
 
-  Object.keys(attributes).forEach(function (key) {
+  Object.keys(attributes).forEach(function(key) {
     attr[key] = attributes[key]
   })
 
   return attr
 }
 
-var groupAttributes = function (box, side, mechMaskId, outClipId) {
+var groupAttributes = function(box, side, mechMaskId, outClipId) {
   var attr = {mask: 'url(#' + mechMaskId + ')'}
 
   if (outClipId) {
@@ -57,13 +57,13 @@ var groupAttributes = function (box, side, mechMaskId, outClipId) {
   return attr
 }
 
-var layerAttributes = function (box) {
+var layerAttributes = function(box) {
   var yTranslate = box[3] + 2 * box[1]
 
   return {transform: 'translate(0,' + yTranslate + ') scale(1,-1)'}
 }
 
-var parseOptions = function (options) {
+var parseOptions = function(options) {
   if (typeof options === 'string') {
     return {id: options}
   }
@@ -75,7 +75,7 @@ var parseOptions = function (options) {
   return options
 }
 
-module.exports = function pcbStackupCore (layers, opts) {
+module.exports = function pcbStackupCore(layers, opts) {
   var options = parseOptions(opts)
   var sorted = sortLayers(layers)
   var id = xid.sanitize(options.id)
@@ -85,7 +85,7 @@ module.exports = function pcbStackupCore (layers, opts) {
   var element = options.createElement || xmlElementString
   var includeNamespace = options.includeNamespace
 
-  return SIDES.reduce(function (result, side) {
+  return SIDES.reduce(function(result, side) {
     var style = boardStyle(element, id + '_', side, color)
 
     var stack = stackLayers(
@@ -108,7 +108,7 @@ module.exports = function pcbStackupCore (layers, opts) {
         'g',
         groupAttributes(box, side, mechMaskId, outClipId),
         stack.layer
-      )
+      ),
     ]
 
     var defsNode = element('defs', {}, defs)
@@ -129,7 +129,7 @@ module.exports = function pcbStackupCore (layers, opts) {
       viewBox: box,
       width: box[2] / 1000,
       height: box[3] / 1000,
-      units: units
+      units: units,
     }
 
     return result

--- a/packages/pcb-stackup-core/lib/sort-layers.js
+++ b/packages/pcb-stackup-core/lib/sort-layers.js
@@ -3,16 +3,16 @@
 
 var wtg = require('whats-that-gerber')
 
-module.exports = function sortLayers (layers) {
+module.exports = function sortLayers(layers) {
   return layers.reduce(assignLayer, {
     top: [],
     bottom: [],
     drills: [],
-    outline: null
+    outline: null,
   })
 }
 
-function assignLayer (result, layer) {
+function assignLayer(result, layer) {
   var type = layer.type
   var side = layer.side
 

--- a/packages/pcb-stackup-core/lib/stack-layers.js
+++ b/packages/pcb-stackup-core/lib/stack-layers.js
@@ -6,7 +6,7 @@ var wtg = require('whats-that-gerber')
 
 var gatherLayers = require('./_gather-layers')
 
-module.exports = function (
+module.exports = function(
   element,
   id,
   side,
@@ -65,7 +65,7 @@ module.exports = function (
     var smMaskId = idPrefix + 'sm-mask'
     var smMaskShape = [
       createRect(element, box, '#fff'),
-      useLayer(element, smLayerId)
+      useLayer(element, smLayerId),
     ]
     var smMaskGroupAtrr = {fill: '#000', stroke: '#000'}
     var smMaskGroup = [element('g', smMaskGroupAtrr, smMaskShape)]
@@ -75,7 +75,7 @@ module.exports = function (
     // add the layer that gets masked
     var smGroupAttr = {mask: 'url(#' + smMaskId + ')'}
     var smGroupShape = [
-      createRect(element, box, 'currentColor', classPrefix + 'sm')
+      createRect(element, box, 'currentColor', classPrefix + 'sm'),
     ]
 
     if (ssLayerId) {
@@ -101,11 +101,11 @@ module.exports = function (
     mechMaskId: mechMaskId,
     outClipId: outLayerId && useOutline ? outLayerId : null,
     box: box,
-    units: units
+    units: units,
   }
 }
 
-function findLayerId (layers, type) {
+function findLayerId(layers, type) {
   var layer
   var i
 
@@ -117,7 +117,7 @@ function findLayerId (layers, type) {
   }
 }
 
-function useLayer (element, id, className, mask) {
+function useLayer(element, id, className, mask) {
   var attr = {'xlink:href': '#' + id}
 
   if (className) {
@@ -133,7 +133,7 @@ function useLayer (element, id, className, mask) {
   return element('use', attr)
 }
 
-function createRect (element, box, fill, className) {
+function createRect(element, box, fill, className) {
   var attr = viewbox.rect(box)
 
   if (fill) {
@@ -147,8 +147,8 @@ function createRect (element, box, fill, className) {
   return element('rect', attr)
 }
 
-function mechMask (element, id, box, drills) {
-  var children = drills.map(function (layer) {
+function mechMask(element, id, box, drills) {
+  var children = drills.map(function(layer) {
     return useLayer(element, layer.id)
   })
 

--- a/packages/pcb-stackup-core/lib/wrap-layer.js
+++ b/packages/pcb-stackup-core/lib/wrap-layer.js
@@ -1,7 +1,7 @@
 // wrap a layer in a group given the layer's converter object
 'use strict'
 
-module.exports = function wrapLayer (element, id, converter, scale, tag) {
+module.exports = function wrapLayer(element, id, converter, scale, tag) {
   var layer = converter.layer
   var attr = {id: id}
 

--- a/packages/pcb-stackup-core/test/expect-xml-nodes.js
+++ b/packages/pcb-stackup-core/test/expect-xml-nodes.js
@@ -10,16 +10,16 @@ chai.use(sinonChai)
 
 // element is a sinon spy, expectations is an array of expectations of {tag, attr, children}
 // children is an array of indices of return values from expectations
-module.exports = function expectXmlNodes (element, expectations) {
+module.exports = function expectXmlNodes(element, expectations) {
   var returnValues = []
 
-  expectations.forEach(function (expectation) {
+  expectations.forEach(function(expectation) {
     var tag = expectation.tag
     var attr = expectation.attr
     var children = expectation.children
 
     if (children) {
-      children = children.map(function (index) {
+      children = children.map(function(index) {
         if (typeof index === 'number') {
           return returnValues[index]
         }

--- a/packages/pcb-stackup-core/test/pcb-stackup_test.js
+++ b/packages/pcb-stackup-core/test/pcb-stackup_test.js
@@ -20,17 +20,17 @@ var element = sinon.spy(xmlElementString)
 var pcbStackupCore = proxyquire('../lib', {
   'xml-element-string': element,
   './sort-layers': sortLayersSpy,
-  './stack-layers': stackLayersStub
+  './stack-layers': stackLayersStub,
 })
 
-var converter = function () {
+var converter = function() {
   return {
     defs: '',
     layer: '',
     viewBox: [0, 0, 0, 0],
     width: 0,
     height: 0,
-    units: ''
+    units: '',
   }
 }
 
@@ -41,11 +41,11 @@ var EXPECTED_DEFAULT_STYLE = [
   '.foobar_sm {color: #004200; opacity: 0.75;}',
   '.foobar_ss {color: #fff;}',
   '.foobar_sp {color: #999;}',
-  '.foobar_out {color: #000;}'
+  '.foobar_out {color: #000;}',
 ].join('\n')
 
-describe('pcb stackup function', function () {
-  beforeEach(function () {
+describe('pcb stackup function', function() {
+  beforeEach(function() {
     element.resetHistory()
     sortLayersSpy.resetHistory()
     stackLayersStub.reset()
@@ -54,24 +54,24 @@ describe('pcb stackup function', function () {
       units: '',
       mechMaskId: '',
       defs: [],
-      layer: []
+      layer: [],
     })
   })
 
-  it('should need an id as an option', function () {
-    expect(function () {
+  it('should need an id as an option', function() {
+    expect(function() {
       pcbStackupCore([], 'foo')
     }).to.not.throw()
-    expect(function () {
+    expect(function() {
       pcbStackupCore([], {id: 'bar'})
     }).to.not.throw()
-    expect(function () {
+    expect(function() {
       pcbStackupCore([])
     }).to.throw(/unique board ID/)
   })
 
-  it('should have a createElement option that defaults to xml-element-string', function () {
-    var customElement = function () {
+  it('should have a createElement option that defaults to xml-element-string', function() {
+    var customElement = function() {
       return 'foo'
     }
 
@@ -82,9 +82,9 @@ describe('pcb stackup function', function () {
     expect(stackLayersStub).to.be.calledWith(customElement)
   })
 
-  it('should return an SVG element with the propper attributes', function () {
+  it('should return an SVG element with the propper attributes', function() {
     var result = pcbStackupCore([], 'foobar')
-    var svgAttr = function (side) {
+    var svgAttr = function(side) {
       return {
         id: 'foobar_' + side,
         xmlns: 'http://www.w3.org/2000/svg',
@@ -97,7 +97,7 @@ describe('pcb stackup function', function () {
         'clip-rule': 'evenodd',
         viewBox: '0 0 0 0',
         width: '0',
-        height: '0'
+        height: '0',
       }
     }
 
@@ -110,7 +110,7 @@ describe('pcb stackup function', function () {
     expect(result.bottom.svg).to.equal(bottomElement.returnValues[0])
   })
 
-  it('should have a default color style', function () {
+  it('should have a default color style', function() {
     var result = pcbStackupCore([], 'foobar')
     var styleSpy = element.withArgs('style', {}, [EXPECTED_DEFAULT_STYLE])
 
@@ -119,10 +119,10 @@ describe('pcb stackup function', function () {
     expect(result.bottom.svg).to.contain(styleSpy.returnValues[0])
   })
 
-  it('should handle user input colors', function () {
+  it('should handle user input colors', function() {
     var options = {
       id: 'foobar',
-      color: {cu: '#123', cf: '#456', sp: '#789'}
+      color: {cu: '#123', cf: '#456', sp: '#789'},
     }
     var result = pcbStackupCore([], options)
     var expectedStyle = [
@@ -132,7 +132,7 @@ describe('pcb stackup function', function () {
       '.foobar_sm {color: #004200; opacity: 0.75;}',
       '.foobar_ss {color: #fff;}',
       '.foobar_sp {color: #789;}',
-      '.foobar_out {color: #000;}'
+      '.foobar_out {color: #000;}',
     ].join('\n')
 
     var styleSpy = element.withArgs('style', {}, [expectedStyle])
@@ -142,7 +142,7 @@ describe('pcb stackup function', function () {
     expect(result.bottom.svg).to.contain(styleSpy.returnValues[0])
   })
 
-  it('should pass the layers to sort layers', function () {
+  it('should pass the layers to sort layers', function() {
     var files = [
       {side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER, converter: converter()},
       {side: wtg.SIDE_TOP, type: wtg.TYPE_SOLDERMASK, converter: converter()},
@@ -152,21 +152,21 @@ describe('pcb stackup function', function () {
       {
         side: wtg.SIDE_BOTTOM,
         type: wtg.TYPE_SOLDERMASK,
-        converter: converter()
+        converter: converter(),
       },
       {
         side: wtg.SIDE_BOTTOM,
         type: wtg.TYPE_SILKSCREEN,
-        converter: converter()
+        converter: converter(),
       },
       {
         side: wtg.SIDE_BOTTOM,
         type: wtg.TYPE_SOLDERPASTE,
-        converter: converter()
+        converter: converter(),
       },
       {side: wtg.SIDE_INNER, type: wtg.TYPE_COPPER, converter: converter()},
       {side: wtg.SIDE_ALL, type: wtg.TYPE_OUTLINE, converter: converter()},
-      {side: wtg.SIDE_ALL, type: wtg.TYPE_DRILL, converter: converter()}
+      {side: wtg.SIDE_ALL, type: wtg.TYPE_DRILL, converter: converter()},
     ]
 
     pcbStackupCore(files, 'this-id')
@@ -192,20 +192,20 @@ describe('pcb stackup function', function () {
     )
   })
 
-  it('should use stack to build result, add mech mask, flip as needed', function () {
+  it('should use stack to build result, add mech mask, flip as needed', function() {
     stackLayersStub.withArgs(element, 'foobar', 'top').returns({
       box: [0, 0, 1000, 1000],
       units: 'mm',
       layer: ['<top-group/>'],
       defs: ['<top-defs/>'],
-      mechMaskId: 'foobar_top_mech-mask'
+      mechMaskId: 'foobar_top_mech-mask',
     })
     stackLayersStub.withArgs(element, 'foobar', 'bottom').returns({
       box: [250, 250, 500, 500],
       units: 'in',
       layer: ['<bottom-group/>'],
       defs: ['<bottom-defs/>'],
-      mechMaskId: 'foobar_bottom_mech-mask'
+      mechMaskId: 'foobar_bottom_mech-mask',
     })
 
     var result = pcbStackupCore([], 'foobar')
@@ -215,12 +215,12 @@ describe('pcb stackup function', function () {
       {
         tag: 'g',
         attr: {mask: 'url(#foobar_top_mech-mask)'},
-        children: ['<top-group/>']
+        children: ['<top-group/>'],
       },
       {
         tag: 'g',
         attr: {transform: 'translate(0,1000) scale(1,-1)'},
-        children: [2]
+        children: [2],
       },
       {
         tag: 'svg',
@@ -229,7 +229,7 @@ describe('pcb stackup function', function () {
           .and(sinon.match.has('width', '1mm'))
           .and(sinon.match.has('height', '1mm'))
           .and(sinon.match.has('viewBox', '0 0 1000 1000')),
-        children: [1, 3]
+        children: [1, 3],
       },
       {tag: 'style', attr: {}, children: [EXPECTED_DEFAULT_STYLE]},
       {tag: 'defs', attr: {}, children: [5, '<bottom-defs/>']},
@@ -237,14 +237,14 @@ describe('pcb stackup function', function () {
         tag: 'g',
         attr: {
           mask: 'url(#foobar_bottom_mech-mask)',
-          transform: 'translate(1000,0) scale(-1,1)'
+          transform: 'translate(1000,0) scale(-1,1)',
         },
-        children: ['<bottom-group/>']
+        children: ['<bottom-group/>'],
       },
       {
         tag: 'g',
         attr: {transform: 'translate(0,1000) scale(1,-1)'},
-        children: [7]
+        children: [7],
       },
       {
         tag: 'svg',
@@ -253,8 +253,8 @@ describe('pcb stackup function', function () {
           .and(sinon.match.has('width', '0.5in'))
           .and(sinon.match.has('height', '0.5in'))
           .and(sinon.match.has('viewBox', '250 250 500 500')),
-        children: [6, 8]
-      }
+        children: [6, 8],
+      },
     ])
 
     expect(result).to.eql({
@@ -265,7 +265,7 @@ describe('pcb stackup function', function () {
         viewBox: [0, 0, 1000, 1000],
         width: 1,
         height: 1,
-        units: 'mm'
+        units: 'mm',
       },
       bottom: {
         svg: values[9],
@@ -274,19 +274,19 @@ describe('pcb stackup function', function () {
         viewBox: [250, 250, 500, 500],
         width: 0.5,
         height: 0.5,
-        units: 'in'
-      }
+        units: 'in',
+      },
     })
   })
 
-  it('should add a clip path if stackLayers returns a outline clip id', function () {
+  it('should add a clip path if stackLayers returns a outline clip id', function() {
     stackLayersStub.withArgs(element, 'foobar', 'top').returns({
       box: [0, 0, 1000, 1000],
       units: 'mm',
       layer: ['<top-group/>'],
       defs: ['<top-defs/>'],
       mechMaskId: 'foobar_top_mech-mask',
-      outClipId: 'foobar_top_out'
+      outClipId: 'foobar_top_out',
     })
     stackLayersStub.withArgs(element, 'foobar', 'bottom').returns({
       box: [250, 250, 500, 500],
@@ -294,7 +294,7 @@ describe('pcb stackup function', function () {
       layer: ['<bottom-group/>'],
       defs: ['<bottom-defs/>'],
       mechMaskId: 'foobar_bottom_mech-mask',
-      outClipId: 'foobar_bottom_out'
+      outClipId: 'foobar_bottom_out',
     })
 
     pcbStackupCore([], {id: 'foobar', maskWithOutline: true})
@@ -303,7 +303,7 @@ describe('pcb stackup function', function () {
       'g',
       {
         mask: 'url(#foobar_top_mech-mask)',
-        'clip-path': 'url(#foobar_top_out)'
+        'clip-path': 'url(#foobar_top_out)',
       },
       ['<top-group/>']
     )
@@ -312,19 +312,19 @@ describe('pcb stackup function', function () {
       {
         transform: 'translate(1000,0) scale(-1,1)',
         mask: 'url(#foobar_bottom_mech-mask)',
-        'clip-path': 'url(#foobar_bottom_out)'
+        'clip-path': 'url(#foobar_bottom_out)',
       },
       ['<bottom-group/>']
     )
   })
 
-  it('should not put xmlns attr in nodes if includeNamespace is false', function () {
+  it('should not put xmlns attr in nodes if includeNamespace is false', function() {
     pcbStackupCore([], {id: 'foo', includeNamespace: false})
 
     expect(element).to.not.be.calledWith('svg', sinon.match.has('xmlns'))
   })
 
-  it('should allow arbitrary stuff in the attributes', function () {
+  it('should allow arbitrary stuff in the attributes', function() {
     pcbStackupCore([], {id: 'foo', attributes: {bar: 'baz'}})
 
     expect(element).to.be.calledWith('svg', sinon.match.has('bar', 'baz'))

--- a/packages/pcb-stackup-core/test/sort-layers_test.js
+++ b/packages/pcb-stackup-core/test/sort-layers_test.js
@@ -6,8 +6,8 @@ var expect = require('chai').expect
 var wtg = require('whats-that-gerber')
 var sortLayers = require('../lib/sort-layers')
 
-describe('sort layers function', function () {
-  it('should reduce layers into object keyed by layer type', function () {
+describe('sort layers function', function() {
+  it('should reduce layers into object keyed by layer type', function() {
     var result = sortLayers([])
 
     expect(result.top).to.eql([])
@@ -16,12 +16,12 @@ describe('sort layers function', function () {
     expect(result.outline).to.equal(null)
   })
 
-  it('should add top layers to the top array', function () {
+  it('should add top layers to the top array', function() {
     var layers = [
       {side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER, converter: {}},
       {side: wtg.SIDE_TOP, type: wtg.TYPE_SOLDERMASK, converter: {}},
       {side: wtg.SIDE_TOP, type: wtg.TYPE_SILKSCREEN, converter: {}},
-      {side: wtg.SIDE_TOP, type: wtg.TYPE_SOLDERPASTE, converter: {}}
+      {side: wtg.SIDE_TOP, type: wtg.TYPE_SOLDERPASTE, converter: {}},
     ]
 
     var result = sortLayers(layers)
@@ -32,12 +32,12 @@ describe('sort layers function', function () {
     expect(result.top).to.eql(layers)
   })
 
-  it('should add bottom layers to the bottom array', function () {
+  it('should add bottom layers to the bottom array', function() {
     var layers = [
       {side: wtg.SIDE_BOTTOM, type: wtg.TYPE_COPPER, converter: {}},
       {side: wtg.SIDE_BOTTOM, type: wtg.TYPE_SOLDERMASK, converter: {}},
       {side: wtg.SIDE_BOTTOM, type: wtg.TYPE_SILKSCREEN, converter: {}},
-      {side: wtg.SIDE_BOTTOM, type: wtg.TYPE_SOLDERPASTE, converter: {}}
+      {side: wtg.SIDE_BOTTOM, type: wtg.TYPE_SOLDERPASTE, converter: {}},
     ]
 
     var result = sortLayers(layers)
@@ -48,11 +48,11 @@ describe('sort layers function', function () {
     expect(result.bottom).to.eql(layers)
   })
 
-  it('should add mechanical layers to the mech array', function () {
+  it('should add mechanical layers to the mech array', function() {
     var layers = [
       {side: wtg.SIDE_ALL, type: wtg.TYPE_OUTLINE, converter: {}},
       {side: wtg.SIDE_ALL, type: wtg.TYPE_DRILL, converter: {defs: 'drl1'}},
-      {side: wtg.SIDE_ALL, type: wtg.TYPE_DRILL, converter: {defs: 'drl2'}}
+      {side: wtg.SIDE_ALL, type: wtg.TYPE_DRILL, converter: {defs: 'drl2'}},
     ]
 
     var result = sortLayers(layers)
@@ -63,11 +63,11 @@ describe('sort layers function', function () {
     expect(result.drills).to.eql([layers[1], layers[2]])
   })
 
-  it('should ignore everything else', function () {
+  it('should ignore everything else', function() {
     var layers = [
       {type: wtg.TYPE_DRAWING, converter: {}},
       {converter: {}},
-      {type: null, converter: {}}
+      {type: null, converter: {}},
     ]
 
     var result = sortLayers(layers)
@@ -78,32 +78,32 @@ describe('sort layers function', function () {
     expect(result.outline).to.equal(null)
   })
 
-  it('should include the externalId field of layers', function () {
+  it('should include the externalId field of layers', function() {
     var layers = [
       {
         side: wtg.SIDE_TOP,
         type: wtg.TYPE_COPPER,
         externalId: 'foo',
-        converter: {foo: 'foo'}
+        converter: {foo: 'foo'},
       },
       {
         side: wtg.SIDE_BOTTOM,
         type: wtg.TYPE_SOLDERMASK,
         externalId: 'bar',
-        converter: {bar: 'bar'}
+        converter: {bar: 'bar'},
       },
       {
         side: wtg.SIDE_ALL,
         type: wtg.TYPE_DRILL,
         externalId: 'baz',
-        converter: {baz: 'baz'}
+        converter: {baz: 'baz'},
       },
       {
         side: wtg.SIDE_ALL,
         type: wtg.TYPE_OUTLINE,
         externalId: 'quux',
-        converter: {quux: 'quux'}
-      }
+        converter: {quux: 'quux'},
+      },
     ]
 
     var result = sortLayers(layers)

--- a/packages/pcb-stackup-core/test/stack-layers_test.js
+++ b/packages/pcb-stackup-core/test/stack-layers_test.js
@@ -12,63 +12,63 @@ var wtg = require('whats-that-gerber')
 var expectXmlNodes = require('./expect-xml-nodes')
 var stackLayers = require('../lib/stack-layers')
 
-var converter = function (defs, layer, viewBox, units) {
+var converter = function(defs, layer, viewBox, units) {
   return {
     defs: defs,
     layer: layer,
     viewBox: viewBox,
     width: viewBox[2] / 1000,
     height: viewBox[3] / 1000,
-    units: units
+    units: units,
   }
 }
 
 var layers = [
   {
     type: wtg.TYPE_COPPER,
-    converter: converter(['<cu-d/>'], ['<cu/>'], [0, 0, 1000, 1000], 'in')
+    converter: converter(['<cu-d/>'], ['<cu/>'], [0, 0, 1000, 1000], 'in'),
   },
   {
     type: wtg.TYPE_SOLDERMASK,
-    converter: converter(['<sm-d/>'], ['<sm/>'], [-10, -10, 1020, 1020], 'in')
+    converter: converter(['<sm-d/>'], ['<sm/>'], [-10, -10, 1020, 1020], 'in'),
   },
   {
     type: wtg.TYPE_SILKSCREEN,
-    converter: converter(['<ss-d/>'], ['<ss/>'], [10, 10, 980, 980], 'in')
+    converter: converter(['<ss-d/>'], ['<ss/>'], [10, 10, 980, 980], 'in'),
   },
   {
     type: wtg.TYPE_SOLDERPASTE,
-    converter: converter(['<sp-d/>'], ['<sp/>'], [100, 100, 800, 800], 'in')
-  }
+    converter: converter(['<sp-d/>'], ['<sp/>'], [100, 100, 800, 800], 'in'),
+  },
 ]
 
 var drills = [
   {
     type: wtg.TYPE_DRILL,
-    converter: converter(['<drl-1/>'], ['<drl1/>'], [0, 0, 25400, 30480], 'mm')
+    converter: converter(['<drl-1/>'], ['<drl1/>'], [0, 0, 25400, 30480], 'mm'),
   },
   {
     type: wtg.TYPE_DRILL,
-    converter: converter(['<drl-2/>'], ['<drl2/>'], [0, 0, 25400, 25400], 'mm')
-  }
+    converter: converter(['<drl-2/>'], ['<drl2/>'], [0, 0, 25400, 25400], 'mm'),
+  },
 ]
 
 var outline = {
   type: wtg.TYPE_OUTLINE,
-  converter: converter(['<out-d/>'], ['<out/>'], [-50, -50, 1100, 1100], 'in')
+  converter: converter(['<out-d/>'], ['<out/>'], [-50, -50, 1100, 1100], 'in'),
 }
 
-describe('stack layers function', function () {
+describe('stack layers function', function() {
   var element
 
-  beforeEach(function () {
-    element = sinon.spy(function (tag, attributes, children) {
+  beforeEach(function() {
+    element = sinon.spy(function(tag, attributes, children) {
       return {tag: tag, attributes: attributes, children: children}
     })
   })
 
-  describe('building the defs and viewbox', function () {
-    it('should add all layer defs to defs', function () {
+  describe('building the defs and viewbox', function() {
+    it('should add all layer defs to defs', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills, outline)
 
       expect(result.defs).to.include.members([
@@ -78,46 +78,46 @@ describe('stack layers function', function () {
         '<sp-d/>',
         '<drl-1/>',
         '<drl-2/>',
-        '<out-d/>'
+        '<out-d/>',
       ])
     })
 
-    it('should add viewBoxes taking units into account', function () {
+    it('should add viewBoxes taking units into account', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills)
 
       expect(result.units).to.equal('in')
       expect(result.box).to.eql([-10, -10, 1020, 1210])
     })
 
-    it('should use the outline layer viewBox if present', function () {
+    it('should use the outline layer viewBox if present', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills, outline)
 
       expect(result.units).to.equal('in')
       expect(result.box).to.eql([-50, -50, 1100, 1100])
     })
 
-    it('should have no units by default, but count units when present', function () {
+    it('should have no units by default, but count units when present', function() {
       var resultNoUnits = stackLayers(element, 'id', 'top', [], [])
 
       var allIn = [
         {type: wtg.TYPE_COPPER, converter: converter([], [], [], 'in')},
         {type: wtg.TYPE_SOLDERMASK, converter: converter([], [], [], 'in')},
-        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'in')}
+        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'in')},
       ]
       var allMm = [
         {type: wtg.TYPE_COPPER, converter: converter([], [], [], 'mm')},
         {type: wtg.TYPE_SOLDERMASK, converter: converter([], [], [], 'mm')},
-        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'mm')}
+        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'mm')},
       ]
       var moreIn = [
         {type: wtg.TYPE_COPPER, converter: converter([], [], [], 'in')},
         {type: wtg.TYPE_SOLDERMASK, converter: converter([], [], [], 'in')},
-        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'mm')}
+        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'mm')},
       ]
       var moreMm = [
         {type: wtg.TYPE_COPPER, converter: converter([], [], [], 'in')},
         {type: wtg.TYPE_SOLDERMASK, converter: converter([], [], [], 'mm')},
-        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'mm')}
+        {type: wtg.TYPE_SILKSCREEN, converter: converter([], [], [], 'mm')},
       ]
 
       var resultAllIn = stackLayers(element, 'id', 'top', allIn, [])
@@ -132,31 +132,31 @@ describe('stack layers function', function () {
       expect(resultMoreMm.units).to.equal('mm')
     })
 
-    it('should wrap the layers and add them to the defs', function () {
+    it('should wrap the layers and add them to the defs', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills)
       var values = element.returnValues
 
       expect(element).to.be.calledWith('g', {id: 'id_top_copper'}, ['<cu/>'])
       expect(element).to.be.calledWith('g', {id: 'id_top_soldermask'}, [
-        '<sm/>'
+        '<sm/>',
       ])
       expect(element).to.be.calledWith('g', {id: 'id_top_silkscreen'}, [
-        '<ss/>'
+        '<ss/>',
       ])
       expect(element).to.be.calledWith('g', {id: 'id_top_solderpaste'}, [
-        '<sp/>'
+        '<sp/>',
       ])
       expect(result.defs).to.include.members(values.slice(0, 4))
     })
 
-    it('should wrap the mech layers and add them to the defs', function () {
+    it('should wrap the mech layers and add them to the defs', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills, outline)
       var values = element.returnValues
       var transform = 'scale(0.03937007874015748,0.03937007874015748)'
       var expected = [
         {id: 'id_top_drill1', transform: transform},
         {id: 'id_top_drill2', transform: transform},
-        {id: 'id_top_outline'}
+        {id: 'id_top_outline'},
       ]
 
       expect(element).to.be.calledWith('g', expected[0], ['<drl1/>'])
@@ -165,7 +165,7 @@ describe('stack layers function', function () {
       expect(result.defs).to.include.members(values.slice(4, 7))
     })
 
-    it('should use a clip path instead of a group for the outline if masking', function () {
+    it('should use a clip path instead of a group for the outline if masking', function() {
       var result = stackLayers(
         element,
         'id',
@@ -179,17 +179,17 @@ describe('stack layers function', function () {
         {
           tag: 'clipPath',
           attr: {id: 'id_top_outline'},
-          children: ['<out/>']
-        }
+          children: ['<out/>'],
+        },
       ])
 
       expect(result.defs).to.contain(values[0])
       expect(element).to.not.be.calledWith('g', {id: 'id_top_outline'}, [
-        '<out/>'
+        '<out/>',
       ])
     })
 
-    it('should not add layers with externalId to defs', function () {
+    it('should not add layers with externalId to defs', function() {
       layers[0].externalId = 'foo'
       drills[0].externalId = 'bar'
       outline.externalId = 'baz'
@@ -222,7 +222,7 @@ describe('stack layers function', function () {
       expect(result.box).to.eql([-50, -50, 1100, 1100])
     })
 
-    it('should add outline to defs even if it has externalId if masking', function () {
+    it('should add outline to defs even if it has externalId if masking', function() {
       var out = {
         type: wtg.TYPE_OUTLINE,
         externalId: 'foo',
@@ -231,74 +231,74 @@ describe('stack layers function', function () {
           ['<out/>'],
           [-50, -50, 1100, 1100],
           'in'
-        )
+        ),
       }
       var result = stackLayers(element, 'id', 'top', layers, drills, out, true)
       var values = expectXmlNodes(element, [
         {
           tag: 'clipPath',
           attr: {id: 'id_top_outline'},
-          children: ['<out/>']
-        }
+          children: ['<out/>'],
+        },
       ])
 
       expect(result.defs).to.contain(values[0])
       expect(element).to.not.be.calledWith('g', {id: 'id_top_outline'}, [
-        '<out/>'
+        '<out/>',
       ])
     })
 
-    it('should add a mech mask to the defs', function () {
+    it('should add a mech mask to the defs', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills, outline)
       var values = expectXmlNodes(element, [
         {
           tag: 'rect',
-          attr: {x: -50, y: -50, width: 1100, height: 1100, fill: '#fff'}
+          attr: {x: -50, y: -50, width: 1100, height: 1100, fill: '#fff'},
         },
         {tag: 'use', attr: {'xlink:href': '#id_top_drill1'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drill2'}},
         {
           tag: 'g',
           attr: {fill: '#000', stroke: '#000'},
-          children: [0, 1, 2]
+          children: [0, 1, 2],
         },
         {
           tag: 'mask',
           attr: {id: 'id_top_mech-mask'},
-          children: [3]
-        }
+          children: [3],
+        },
       ])
 
       expect(result.defs).to.contain(values[4])
     })
 
-    it('should handle being told to use the outline when it is missing', function () {
+    it('should handle being told to use the outline when it is missing', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills, null, true)
       var values = expectXmlNodes(element, [
         {
           tag: 'rect',
-          attr: {x: -10, y: -10, width: 1020, height: 1210, fill: '#fff'}
+          attr: {x: -10, y: -10, width: 1020, height: 1210, fill: '#fff'},
         },
         {tag: 'use', attr: {'xlink:href': '#id_top_drill1'}},
         {tag: 'use', attr: {'xlink:href': '#id_top_drill2'}},
         {
           tag: 'g',
           attr: {fill: '#000', stroke: '#000'},
-          children: [0, 1, 2]
+          children: [0, 1, 2],
         },
         {
           tag: 'mask',
           attr: {id: 'id_top_mech-mask'},
-          children: [3]
-        }
+          children: [3],
+        },
       ])
 
       expect(result.defs).to.contain(values[4])
     })
   })
 
-  describe('building the main group', function () {
-    it('should start with a fr4 rectangle the size of the box', function () {
+  describe('building the main group', function() {
+    it('should start with a fr4 rectangle the size of the box', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills, outline)
       var values = expectXmlNodes(element, [
         {
@@ -309,20 +309,20 @@ describe('stack layers function', function () {
             width: 1100,
             height: 1100,
             class: 'id_fr4',
-            fill: 'currentColor'
-          }
-        }
+            fill: 'currentColor',
+          },
+        },
       ])
 
       expect(result.layer[0]).to.equal(values[0])
     })
 
-    it('should add copper and copper finish if there is a copper layer', function () {
+    it('should add copper and copper finish if there is a copper layer', function() {
       var converters = [
         {
           type: wtg.TYPE_COPPER,
-          converter: converter([], [], [0, 0, 1000, 1000], 'in')
-        }
+          converter: converter([], [], [0, 0, 1000, 1000], 'in'),
+        },
       ]
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
@@ -331,7 +331,7 @@ describe('stack layers function', function () {
         {
           tag: 'mask',
           attr: {id: 'id_top_cf-mask'},
-          children: [1]
+          children: [1],
         },
         {
           tag: 'use',
@@ -339,8 +339,8 @@ describe('stack layers function', function () {
             'xlink:href': '#id_top_copper',
             class: 'id_cu',
             fill: 'currentColor',
-            stroke: 'currentColor'
-          }
+            stroke: 'currentColor',
+          },
         },
         {
           tag: 'use',
@@ -349,25 +349,25 @@ describe('stack layers function', function () {
             mask: 'url(#id_top_cf-mask)',
             class: 'id_cf',
             fill: 'currentColor',
-            stroke: 'currentColor'
-          }
-        }
+            stroke: 'currentColor',
+          },
+        },
       ])
 
       expect(result.defs.slice(-1)).to.eql([values[2]])
       expect(result.layer.slice(-2)).to.eql([values[3], values[4]])
     })
 
-    it('should use the soldermask to mask the copper finish if it exists', function () {
+    it('should use the soldermask to mask the copper finish if it exists', function() {
       var converters = [
         {
           type: wtg.TYPE_COPPER,
-          converter: converter([], [], [0, 0, 1000, 1000], 'in')
+          converter: converter([], [], [0, 0, 1000, 1000], 'in'),
         },
         {
           type: wtg.TYPE_SOLDERMASK,
-          converter: converter([], [], [-10, -10, 1020, 1020], 'in')
-        }
+          converter: converter([], [], [-10, -10, 1020, 1020], 'in'),
+        },
       ]
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
@@ -376,32 +376,32 @@ describe('stack layers function', function () {
         {
           tag: 'mask',
           attr: {id: 'id_top_cf-mask'},
-          children: [1]
-        }
+          children: [1],
+        },
       ])
 
       expect(result.defs).to.contain(values[2])
     })
 
-    it('should add the soldermask', function () {
+    it('should add the soldermask', function() {
       var converters = [
         {
           type: wtg.TYPE_SOLDERMASK,
-          converter: converter([], [], [0, 0, 500, 500], 'in')
-        }
+          converter: converter([], [], [0, 0, 500, 500], 'in'),
+        },
       ]
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
         {
           tag: 'rect',
-          attr: {x: 0, y: 0, width: 500, height: 500, fill: '#fff'}
+          attr: {x: 0, y: 0, width: 500, height: 500, fill: '#fff'},
         },
         {tag: 'use', attr: {'xlink:href': '#id_top_soldermask'}},
         {tag: 'g', attr: {fill: '#000', stroke: '#000'}, children: [0, 1]},
         {
           tag: 'mask',
           attr: {id: 'id_top_sm-mask'},
-          children: [2]
+          children: [2],
         },
         {
           tag: 'rect',
@@ -411,26 +411,26 @@ describe('stack layers function', function () {
             width: 500,
             height: 500,
             class: 'id_sm',
-            fill: 'currentColor'
-          }
+            fill: 'currentColor',
+          },
         },
-        {tag: 'g', attr: {mask: 'url(#id_top_sm-mask)'}, children: [4]}
+        {tag: 'g', attr: {mask: 'url(#id_top_sm-mask)'}, children: [4]},
       ])
 
       expect(result.defs).to.contain(values[3])
       expect(result.layer.slice(-1)).to.eql([values[5]])
     })
 
-    it('should add silkscreen when there is a mask and a silk', function () {
+    it('should add silkscreen when there is a mask and a silk', function() {
       var converters = [
         {
           type: wtg.TYPE_SOLDERMASK,
-          converter: converter([], [], [0, 0, 500, 500], 'in')
+          converter: converter([], [], [0, 0, 500, 500], 'in'),
         },
         {
           type: wtg.TYPE_SILKSCREEN,
-          converter: converter([], [], [10, 10, 480, 480], 'in')
-        }
+          converter: converter([], [], [10, 10, 480, 480], 'in'),
+        },
       ]
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
@@ -442,8 +442,8 @@ describe('stack layers function', function () {
             width: 500,
             height: 500,
             class: 'id_sm',
-            fill: 'currentColor'
-          }
+            fill: 'currentColor',
+          },
         },
         {
           tag: 'use',
@@ -451,21 +451,21 @@ describe('stack layers function', function () {
             'xlink:href': '#id_top_silkscreen',
             class: 'id_ss',
             fill: 'currentColor',
-            stroke: 'currentColor'
-          }
+            stroke: 'currentColor',
+          },
         },
-        {tag: 'g', attr: {mask: 'url(#id_top_sm-mask)'}, children: [0, 1]}
+        {tag: 'g', attr: {mask: 'url(#id_top_sm-mask)'}, children: [0, 1]},
       ])
 
       expect(result.layer.slice(-1)).to.eql([values[2]])
     })
 
-    it('should add solderpaste', function () {
+    it('should add solderpaste', function() {
       var converters = [
         {
           type: wtg.TYPE_SOLDERPASTE,
-          converter: converter([], [], [0, 0, 500, 500], 'in')
-        }
+          converter: converter([], [], [0, 0, 500, 500], 'in'),
+        },
       ]
       var result = stackLayers(element, 'id', 'top', converters, [])
       var values = expectXmlNodes(element, [
@@ -475,21 +475,21 @@ describe('stack layers function', function () {
             'xlink:href': '#id_top_solderpaste',
             class: 'id_sp',
             fill: 'currentColor',
-            stroke: 'currentColor'
-          }
-        }
+            stroke: 'currentColor',
+          },
+        },
       ])
 
       expect(result.layer.slice(-1)).to.eql(values)
     })
 
-    it('should return the id of the mechanical mask', function () {
+    it('should return the id of the mechanical mask', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills)
 
       expect(result.mechMaskId).to.equal('id_top_mech-mask')
     })
 
-    it('should return the id of the outline clip path', function () {
+    it('should return the id of the outline clip path', function() {
       var result = stackLayers(
         element,
         'id',
@@ -503,7 +503,7 @@ describe('stack layers function', function () {
       expect(result.outClipId).to.equal('id_top_outline')
     })
 
-    it('should add the outline to the normal layer if not used to clip', function () {
+    it('should add the outline to the normal layer if not used to clip', function() {
       var result = stackLayers(element, 'id', 'top', layers, drills, outline)
       var values = expectXmlNodes(element, [
         {
@@ -512,26 +512,26 @@ describe('stack layers function', function () {
             'xlink:href': '#id_top_outline',
             class: 'id_out',
             fill: 'currentColor',
-            stroke: 'currentColor'
-          }
-        }
+            stroke: 'currentColor',
+          },
+        },
       ])
 
       expect(result.layer.slice(-1)).to.eql(values)
     })
 
-    it('should not add the outline if used in the mech mask', function () {
+    it('should not add the outline if used in the mech mask', function() {
       stackLayers(element, 'id', 'top', layers, drills, outline, true)
 
       expect(element).to.not.be.calledWith('use', {
         'xlink:href': '#id_top_outline',
         class: 'id_out',
         fill: 'currentColor',
-        stroke: 'currentColor'
+        stroke: 'currentColor',
       })
     })
 
-    it('should use external ids for uses if given', function () {
+    it('should use external ids for uses if given', function() {
       layers[0].externalId = 'foo'
       drills[0].externalId = 'bar'
 
@@ -560,7 +560,7 @@ describe('stack layers function', function () {
       )
     })
 
-    it('should use external drill id for use if not masking', function () {
+    it('should use external drill id for use if not masking', function() {
       outline.externalId = 'baz'
 
       var result = stackLayers(element, 'id', 'top', layers, drills, outline)
@@ -571,9 +571,9 @@ describe('stack layers function', function () {
             'xlink:href': '#baz',
             class: 'id_out',
             fill: 'currentColor',
-            stroke: 'currentColor'
-          }
-        }
+            stroke: 'currentColor',
+          },
+        },
       ])
 
       delete outline.externalId

--- a/packages/pcb-stackup-core/test/wrap-layer_test.js
+++ b/packages/pcb-stackup-core/test/wrap-layer_test.js
@@ -11,8 +11,8 @@ chai.use(sinonChai)
 
 var wrapLayer = require('../lib/wrap-layer')
 
-describe('wrap layer function', function () {
-  it('should return the layer value wrapped in a group with an id', function () {
+describe('wrap layer function', function() {
+  it('should return the layer value wrapped in a group with an id', function() {
     var layer = {layer: ['SOME_STUFF']}
     var element = sinon.spy(xmlElementString)
     var result = wrapLayer(element, 'id', layer)
@@ -22,7 +22,7 @@ describe('wrap layer function', function () {
     expect(result).to.equal(element.returnValues[0])
   })
 
-  it('should be able to scale the layer', function () {
+  it('should be able to scale the layer', function() {
     var layer = {layer: ['SOME_STUFF']}
     var element = sinon.spy(xmlElementString)
     var result = wrapLayer(element, 'foobar', layer, 25.4)
@@ -32,7 +32,7 @@ describe('wrap layer function', function () {
     expect(result).to.equal(element.returnValues[0])
   })
 
-  it('should not add a transformation if the scale is 1', function () {
+  it('should not add a transformation if the scale is 1', function() {
     var layer = {layer: ['SOME_STUFF']}
     var element = sinon.spy(xmlElementString)
     var result = wrapLayer(element, 'id', layer, 1)
@@ -42,7 +42,7 @@ describe('wrap layer function', function () {
     expect(result).to.equal(element.returnValues[0])
   })
 
-  it('should be able to use a tag other than <g>', function () {
+  it('should be able to use a tag other than <g>', function() {
     var layer = {layer: ['SOME_STUFF']}
     var element = sinon.spy(xmlElementString)
     var result = wrapLayer(element, 'id', layer, 1, 'clipPath')

--- a/packages/pcb-stackup/example/index.js
+++ b/packages/pcb-stackup/example/index.js
@@ -18,7 +18,7 @@ const GERBER_PATHS = [
   'arduino-uno.plc',
   'arduino-uno.sol',
   'arduino-uno.stc',
-  'arduino-uno.sts'
+  'arduino-uno.sts',
 ].map(filename => path.join(GERBERS_DIR, filename))
 
 runWaterfall([renderStackup, writeStackup], error => {
@@ -27,19 +27,19 @@ runWaterfall([renderStackup, writeStackup], error => {
   console.log(`Wrote:\n  ${TOP_OUT}\n  ${BOTTOM_OUT}`)
 })
 
-function renderStackup (done) {
+function renderStackup(done) {
   const layers = GERBER_PATHS.map(filename => ({
     filename,
-    gerber: fs.createReadStream(filename)
+    gerber: fs.createReadStream(filename),
   }))
 
   pcbStackup(layers, done)
 }
 
-function writeStackup (stackup, done) {
+function writeStackup(stackup, done) {
   const tasks = [
     next => fs.writeFile(TOP_OUT, stackup.top.svg, next),
-    next => fs.writeFile(BOTTOM_OUT, stackup.bottom.svg, next)
+    next => fs.writeFile(BOTTOM_OUT, stackup.bottom.svg, next),
   ]
 
   runParallel(tasks, done)

--- a/packages/pcb-stackup/index.js
+++ b/packages/pcb-stackup/index.js
@@ -7,11 +7,11 @@ var gerberToSvg = require('gerber-to-svg')
 var createStackup = require('pcb-stackup-core')
 var wtg = require('whats-that-gerber')
 
-var getFilename = function (layer) {
+var getFilename = function(layer) {
   return layer.filename
 }
 
-var getValidationMessage = function (layer) {
+var getValidationMessage = function(layer) {
   var result = wtg.validate(layer)
 
   if (layer.filename || result.valid) return ''
@@ -19,7 +19,7 @@ var getValidationMessage = function (layer) {
   return 'has invalid side/type (' + layer.side + '/' + layer.type + ')'
 }
 
-var pcbStackup = function (layers, options, done) {
+var pcbStackup = function(layers, options, done) {
   if (typeof options === 'function') {
     done = options
     options = {}
@@ -29,7 +29,7 @@ var pcbStackup = function (layers, options, done) {
 
   var validationMessage = layers
     .map(getValidationMessage)
-    .map(function (msg, i) {
+    .map(function(msg, i) {
       return msg && 'layer ' + i + ' ' + msg
     })
     .filter(Boolean)
@@ -44,7 +44,7 @@ var pcbStackup = function (layers, options, done) {
   }
 
   if (options.createElement != null) {
-    layers.forEach(function (layer) {
+    layers.forEach(function(layer) {
       layer.options = layer.options || {}
       layer.options.createElement = options.createElement
     })
@@ -53,7 +53,7 @@ var pcbStackup = function (layers, options, done) {
   var layerCount = layers.length
   var stackupLayers = []
 
-  var finishLayer = function () {
+  var finishLayer = function() {
     if (--layerCount < 1) {
       var stackup = createStackup(stackupLayers, options)
 
@@ -69,7 +69,7 @@ var pcbStackup = function (layers, options, done) {
 
   var gerberIds = wtg(layers.map(getFilename))
 
-  layers.forEach(function (layer) {
+  layers.forEach(function(layer) {
     var gerberId = gerberIds[layer.filename]
     var layerSide = layer.side || gerberId.side
     var layerType = layer.type || gerberId.type
@@ -98,7 +98,7 @@ var pcbStackup = function (layers, options, done) {
       type: layerType,
       filename: layer.filename,
       converter: converter,
-      options: layerOptions
+      options: layerOptions,
     })
 
     if (usePreConverted) {

--- a/packages/pcb-stackup/integration/get-results.js
+++ b/packages/pcb-stackup/integration/get-results.js
@@ -6,7 +6,7 @@ const runWaterfall = require('run-waterfall')
 const debug = require('debug')('tracespace/pcb-stackup/integration')
 const pcbStackup = require('..')
 
-module.exports = function getBoardResults (board, done) {
+module.exports = function getBoardResults(board, done) {
   debug(`Render started for ${board.name}`)
 
   const options = Object.assign({id: `__${board.name}`}, board.options)
@@ -16,26 +16,26 @@ module.exports = function getBoardResults (board, done) {
     return {
       filename: filename,
       gerber: layer.source,
-      options: Object.assign({id: `__${filename}`}, layer.options)
+      options: Object.assign({id: `__${filename}`}, layer.options),
     }
   })
 
   runWaterfall(
     [
       next => pcbStackup(layers, options, next),
-      (stackup, next) => next(null, makeBoardResult(board, stackup))
+      (stackup, next) => next(null, makeBoardResult(board, stackup)),
     ],
     done
   )
 }
 
-function makeBoardResult (board, stackup) {
+function makeBoardResult(board, stackup) {
   return Object.assign(
     {
       specs: [
         {name: 'top', render: stackup.top.svg},
-        {name: 'bottom', render: stackup.bottom.svg}
-      ]
+        {name: 'bottom', render: stackup.bottom.svg},
+      ],
     },
     board
   )

--- a/packages/pcb-stackup/integration/pcb-stackup-snapshot.test.js
+++ b/packages/pcb-stackup/integration/pcb-stackup-snapshot.test.js
@@ -10,12 +10,12 @@ const getBoardResults = require('./get-results')
 const SIDES = ['top', 'bottom']
 const BOARDS = getBoards.sync().filter(b => !b.skipSnapshot)
 
-describe(`pcb-stackup :: integration snapshots`, function () {
+describe(`pcb-stackup :: integration snapshots`, function() {
   BOARDS.forEach((board, index) =>
-    describe(board.name, function () {
+    describe(board.name, function() {
       let boardResults
 
-      before(function (done) {
+      before(function(done) {
         if (process.env.INTEGRATION !== '1') return this.skip()
 
         getBoardResults(board, (error, results) => {
@@ -26,7 +26,7 @@ describe(`pcb-stackup :: integration snapshots`, function () {
       })
 
       SIDES.forEach(side =>
-        it(`renders ${side}`, function () {
+        it(`renders ${side}`, function() {
           const result = boardResults.specs.find(s => s.name === side)
           snapshot(format(result.render).split('\n'))
         })

--- a/packages/pcb-stackup/test.js
+++ b/packages/pcb-stackup/test.js
@@ -9,79 +9,79 @@ var pcbStackup = require('.')
 
 var emptyGerber = 'G04 empty gerber*\nM02*\n'
 
-describe('easy stackup function', function () {
-  it('should accept and call node style callback', function (done) {
-    pcbStackup([], function (error, stackup) {
+describe('easy stackup function', function() {
+  it('should accept and call node style callback', function(done) {
+    pcbStackup([], function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       done()
     })
   })
 
-  it('should accept options as the second argument', function (done) {
-    pcbStackup([], {maskWithOutline: false}, function (error, stackup) {
+  it('should accept options as the second argument', function(done) {
+    pcbStackup([], {maskWithOutline: false}, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       done()
     })
   })
 
-  it('should fail without a callback', function () {
+  it('should fail without a callback', function() {
     expect(pcbStackup.bind(pcbStackup, [])).to.throw(TypeError)
     expect(pcbStackup.bind(pcbStackup, [], {})).to.throw(TypeError)
   })
 
-  it('should accept a layer with a gerber string and filename', function (done) {
+  it('should accept a layer with a gerber string and filename', function(done) {
     var layers = [{gerber: emptyGerber, filename: 'foo'}]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       done()
     })
   })
 
-  it('should accept a layer with a gerber string and type', function (done) {
+  it('should accept a layer with a gerber string and type', function(done) {
     var layers = [
-      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER}
+      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER},
     ]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       done()
     })
   })
 
-  it('should error if no filename or type is given', function (done) {
+  it('should error if no filename or type is given', function(done) {
     var layers = [{gerber: emptyGerber}]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error.message).to.match(/layer 0 .+ missing/)
       done()
     })
   })
 
-  it('should error when invalid layer type is given', function (done) {
+  it('should error when invalid layer type is given', function(done) {
     var layers = [{gerber: emptyGerber, type: 'wrong'}]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error.message).to.match(/layer 0 .+ invalid/)
       done()
     })
   })
 
-  it('should not overwrite layer id', function (done) {
+  it('should not overwrite layer id', function(done) {
     var layers = [
       {
         gerber: emptyGerber,
         side: wtg.SIDE_TOP,
         type: wtg.TYPE_COPPER,
-        options: {id: 'test-id'}
-      }
+        options: {id: 'test-id'},
+      },
     ]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       expect(stackup.layers).to.have.lengthOf(1)
@@ -91,10 +91,10 @@ describe('easy stackup function', function () {
   })
 
   // TODO(mc, 2018-08-02): fix this test so it actually tests something
-  it.skip('should not overwrite stackup id', function (done) {
+  it.skip('should not overwrite stackup id', function(done) {
     var layers = [{gerber: emptyGerber, type: 'tcu'}]
 
-    pcbStackup(layers, {id: 'test-id'}, function (error, stackup) {
+    pcbStackup(layers, {id: 'test-id'}, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       // TODO: test for actual id
@@ -102,10 +102,10 @@ describe('easy stackup function', function () {
     })
   })
 
-  it('should callback with top, bottom and layer array', function (done) {
+  it('should callback with top, bottom and layer array', function(done) {
     var layers = [{gerber: emptyGerber, filename: 'foo'}]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       expect(stackup).to.be.an('object')
@@ -122,17 +122,17 @@ describe('easy stackup function', function () {
     })
   })
 
-  it('respects plotAsOutline option', function (done) {
+  it('respects plotAsOutline option', function(done) {
     var layers = [
       {
         gerber: emptyGerber,
         side: wtg.SIDE_TOP,
         type: wtg.TYPE_COPPER,
-        options: {plotAsOutline: true}
-      }
+        options: {plotAsOutline: true},
+      },
     ]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       expect(stackup.layers[0].options.plotAsOutline).to.equal(true)
@@ -140,13 +140,13 @@ describe('easy stackup function', function () {
     })
   })
 
-  it('handles multiple layers', function (done) {
+  it('handles multiple layers', function(done) {
     var layers = [
       {gerber: emptyGerber, side: wtg.SIDE_BOTTOM, type: wtg.TYPE_COPPER},
-      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER}
+      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER},
     ]
 
-    pcbStackup(layers, function (error, stackup) {
+    pcbStackup(layers, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup).to.satisfy(identity)
       expect(stackup.layers).to.have.lengthOf(layers.length)
@@ -154,16 +154,16 @@ describe('easy stackup function', function () {
     })
   })
 
-  it('can be passed back its own output', function (done) {
+  it('can be passed back its own output', function(done) {
     var layers = [
       {gerber: emptyGerber, side: wtg.SIDE_BOTTOM, type: wtg.TYPE_COPPER},
-      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER}
+      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER},
     ]
 
-    pcbStackup(layers, function (error, stackup1) {
+    pcbStackup(layers, function(error, stackup1) {
       expect(error).to.equal(null)
 
-      pcbStackup(stackup1.layers, function (error, stackup2) {
+      pcbStackup(stackup1.layers, function(error, stackup2) {
         expect(error).to.equal(null)
         expect(stackup2).to.satisfy(identity)
         done()
@@ -171,18 +171,18 @@ describe('easy stackup function', function () {
     })
   })
 
-  it('sets the createElement option', function (done) {
+  it('sets the createElement option', function(done) {
     var layers = [
       {gerber: emptyGerber, side: wtg.SIDE_BOTTOM, type: wtg.TYPE_COPPER},
-      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER}
+      {gerber: emptyGerber, side: wtg.SIDE_TOP, type: wtg.TYPE_COPPER},
     ]
     var options = {
-      createElement: function () {
+      createElement: function() {
         return 1
-      }
+      },
     }
 
-    pcbStackup(layers, options, function (error, stackup) {
+    pcbStackup(layers, options, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup.layers[0].converter['_element']()).to.equal(1)
       expect(stackup.layers[1].converter['_element']()).to.equal(1)
@@ -190,7 +190,7 @@ describe('easy stackup function', function () {
     })
   })
 
-  it('overrides the createElement option', function (done) {
+  it('overrides the createElement option', function(done) {
     var layers = [
       {gerber: emptyGerber, side: wtg.SIDE_BOTTOM, type: wtg.TYPE_COPPER},
       {
@@ -198,19 +198,19 @@ describe('easy stackup function', function () {
         side: wtg.SIDE_TOP,
         type: wtg.TYPE_COPPER,
         options: {
-          createElement: function () {
+          createElement: function() {
             return 2
-          }
-        }
-      }
+          },
+        },
+      },
     ]
     var options = {
-      createElement: function () {
+      createElement: function() {
         return 1
-      }
+      },
     }
 
-    pcbStackup(layers, options, function (error, stackup) {
+    pcbStackup(layers, options, function(error, stackup) {
       expect(error).to.equal(null)
       expect(stackup.layers[0].converter['_element']()).to.equal(1)
       expect(stackup.layers[1].converter['_element']()).to.equal(1)
@@ -218,19 +218,19 @@ describe('easy stackup function', function () {
     })
   })
 
-  it('sets threshold for filling outline gaps', function (done) {
+  it('sets threshold for filling outline gaps', function(done) {
     var layers = [
-      {gerber: emptyGerber, side: wtg.SIDE_ALL, type: wtg.TYPE_OUTLINE}
+      {gerber: emptyGerber, side: wtg.SIDE_ALL, type: wtg.TYPE_OUTLINE},
     ]
 
     var options = {outlineGapFill: 2}
 
-    pcbStackup(layers, options, function (error, stackup) {
+    pcbStackup(layers, options, function(error, stackup) {
       var options = {outlineGapFill: 3}
 
       expect(error).to.equal(null)
       expect(stackup.layers[0].options.plotAsOutline).to.equal(2)
-      pcbStackup(stackup.layers, options, function (error, stackup) {
+      pcbStackup(stackup.layers, options, function(error, stackup) {
         expect(error).to.equal(null)
         expect(stackup.layers[0].options.plotAsOutline).to.equal(3)
         done()

--- a/packages/whats-that-gerber/index.js
+++ b/packages/whats-that-gerber/index.js
@@ -10,17 +10,17 @@ module.exports = whatsThatGerber
 module.exports.validate = validate
 module.exports.getAllLayers = getAllLayers
 
-Object.keys(constants).forEach(function (constantName) {
+Object.keys(constants).forEach(function(constantName) {
   module.exports[constantName] = constants[constantName]
 })
 
-function whatsThatGerber (filenames) {
+function whatsThatGerber(filenames) {
   if (typeof filenames === 'string') filenames = [filenames]
 
   var matches = flatMap(filenames, getMatches)
   var commonCad = getCommonCad(matches)
 
-  return filenames.reduce(function (result, filename) {
+  return filenames.reduce(function(result, filename) {
     var match = _selectMatch(matches, filename, commonCad)
     result[filename] = match
       ? {type: match.type, side: match.side}
@@ -30,38 +30,38 @@ function whatsThatGerber (filenames) {
   }, {})
 }
 
-function getAllLayers () {
-  return layerTypes.map(function (layer) {
+function getAllLayers() {
+  return layerTypes.map(function(layer) {
     return {type: layer.type, side: layer.side}
   })
 }
 
-function validate (target) {
+function validate(target) {
   return {
     valid: layerTypes.some(_validateLayer),
     side: layerTypes.some(_validateSide) ? target.side : null,
-    type: layerTypes.some(_validateType) ? target.type : null
+    type: layerTypes.some(_validateType) ? target.type : null,
   }
 
-  function _validateLayer (layer) {
+  function _validateLayer(layer) {
     return layer.side === target.side && layer.type === target.type
   }
 
-  function _validateSide (layer) {
+  function _validateSide(layer) {
     return layer.side === target.side
   }
 
-  function _validateType (layer) {
+  function _validateType(layer) {
     return layer.type === target.type
   }
 }
 
-function _selectMatch (matches, filename, cad) {
-  var filenameMatches = matches.filter(function (match) {
+function _selectMatch(matches, filename, cad) {
+  var filenameMatches = matches.filter(function(match) {
     return match.filename === filename
   })
 
-  var result = filenameMatches.find(function (match) {
+  var result = filenameMatches.find(function(match) {
     return match.cad === cad
   })
 

--- a/packages/whats-that-gerber/lib/constants.js
+++ b/packages/whats-that-gerber/lib/constants.js
@@ -25,5 +25,5 @@ module.exports = {
   _CAD_EAGLE: 'eagle',
   _CAD_GEDA_PCB: 'geda-pcb',
   _CAD_ORCAD: 'orcad',
-  _CAD_DIPTRACE: 'diptrace'
+  _CAD_DIPTRACE: 'diptrace',
 }

--- a/packages/whats-that-gerber/lib/flat-map.js
+++ b/packages/whats-that-gerber/lib/flat-map.js
@@ -1,7 +1,7 @@
 'use strict'
 
-module.exports = function flatMap (collection, iterator) {
-  return collection.reduce(function iterate (result, element) {
+module.exports = function flatMap(collection, iterator) {
+  return collection.reduce(function iterate(result, element) {
     return result.concat(iterator(element))
   }, [])
 }

--- a/packages/whats-that-gerber/lib/get-common-cad.js
+++ b/packages/whats-that-gerber/lib/get-common-cad.js
@@ -1,13 +1,13 @@
 'use strict'
 
-module.exports = function getCommonCad (matches) {
-  var cadCount = matches.reduce(function (counts, match) {
+module.exports = function getCommonCad(matches) {
+  var cadCount = matches.reduce(function(counts, match) {
     counts[match.cad] = counts[match.cad] + 1 || 1
     return counts
   }, {})
 
   return Object.keys(cadCount).reduce(
-    function (maxAndName, name) {
+    function(maxAndName, name) {
       var count = cadCount[name]
       if (count > maxAndName.max) return {max: count, name: name}
       return maxAndName

--- a/packages/whats-that-gerber/lib/get-matches.js
+++ b/packages/whats-that-gerber/lib/get-matches.js
@@ -4,10 +4,10 @@ var extend = require('xtend')
 
 var matchers = require('./matchers')
 
-module.exports = function getMatches (filename) {
+module.exports = function getMatches(filename) {
   return matchers.map(matcherToFileMatches).filter(Boolean)
 
-  function matcherToFileMatches (matcher) {
+  function matcherToFileMatches(matcher) {
     if (!matcher.match.test(filename)) return null
     return extend(matcher, {filename: filename})
   }

--- a/packages/whats-that-gerber/lib/layer-types.js
+++ b/packages/whats-that-gerber/lib/layer-types.js
@@ -14,8 +14,8 @@ module.exports = [
       {match: /top\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]cu/, cad: c._CAD_KICAD},
       {match: /copper_top/, cad: c._CAD_EAGLE},
-      {match: /top copper/, cad: null}
-    ]
+      {match: /top copper/, cad: null},
+    ],
   },
   {
     type: c.TYPE_SOLDERMASK,
@@ -29,8 +29,8 @@ module.exports = [
       {match: /topmask\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]mask/, cad: c._CAD_KICAD},
       {match: /soldermask_top/, cad: c._CAD_EAGLE},
-      {match: /top solder resist/, cad: null}
-    ]
+      {match: /top solder resist/, cad: null},
+    ],
   },
   {
     type: c.TYPE_SILKSCREEN,
@@ -44,8 +44,8 @@ module.exports = [
       {match: /topsilk\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]silks/, cad: c._CAD_KICAD},
       {match: /silkscreen_top/, cad: c._CAD_EAGLE},
-      {match: /top silk screen/, cad: null}
-    ]
+      {match: /top silk screen/, cad: null},
+    ],
   },
   {
     type: c.TYPE_SOLDERPASTE,
@@ -58,8 +58,8 @@ module.exports = [
       {ext: 'tcream\\.ger', cad: c._CAD_EAGLE_OSHPARK},
       {match: /toppaste\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]paste/, cad: c._CAD_KICAD},
-      {match: /solderpaste_top/, cad: c._CAD_EAGLE}
-    ]
+      {match: /solderpaste_top/, cad: c._CAD_EAGLE},
+    ],
   },
   {
     type: c.TYPE_COPPER,
@@ -72,8 +72,8 @@ module.exports = [
       {match: /bottom\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]cu/, cad: c._CAD_KICAD},
       {match: /copper_bottom/, cad: c._CAD_EAGLE},
-      {match: /bottom copper/, cad: null}
-    ]
+      {match: /bottom copper/, cad: null},
+    ],
   },
   {
     type: c.TYPE_SOLDERMASK,
@@ -87,8 +87,8 @@ module.exports = [
       {match: /bottommask\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]mask/, cad: c._CAD_KICAD},
       {match: /soldermask_bottom/, cad: c._CAD_EAGLE},
-      {match: /bottom solder resist/, cad: null}
-    ]
+      {match: /bottom solder resist/, cad: null},
+    ],
   },
   {
     type: c.TYPE_SILKSCREEN,
@@ -102,8 +102,8 @@ module.exports = [
       {match: /bottomsilk\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]silks/, cad: c._CAD_KICAD},
       {match: /silkscreen_bottom/, cad: c._CAD_EAGLE},
-      {match: /bottom silk screen/, cad: null}
-    ]
+      {match: /bottom silk screen/, cad: null},
+    ],
   },
   {
     type: c.TYPE_SOLDERPASTE,
@@ -116,8 +116,8 @@ module.exports = [
       {ext: 'bcream\\.ger', cad: c._CAD_EAGLE_OSHPARK},
       {match: /bottompaste\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]paste/, cad: c._CAD_KICAD},
-      {match: /solderpaste_bottom/, cad: c._CAD_EAGLE}
-    ]
+      {match: /solderpaste_bottom/, cad: c._CAD_EAGLE},
+    ],
   },
   {
     type: c.TYPE_COPPER,
@@ -127,8 +127,8 @@ module.exports = [
       {ext: 'gp?\\d+', cad: [c._CAD_KICAD, c._CAD_ALTIUM]},
       {ext: 'in\\d+', cad: c._CAD_ORCAD},
       {ext: 'internalplane\\d+\\.ger', cad: c._CAD_EAGLE_OSHPARK},
-      {match: /in(?:ner)?\d+[._]cu/, cad: c._CAD_KICAD}
-    ]
+      {match: /in(?:ner)?\d+[._]cu/, cad: c._CAD_KICAD},
+    ],
   },
   {
     type: c.TYPE_OUTLINE,
@@ -144,8 +144,8 @@ module.exports = [
       {match: /boardoutline/, cad: [c._CAD_EAGLE_OSHPARK, c._CAD_DIPTRACE]},
       {match: /edge[._]cuts/, cad: c._CAD_KICAD},
       {match: /profile/, cad: c._CAD_EAGLE},
-      {match: /mechanical \d+/, cad: null}
-    ]
+      {match: /mechanical \d+/, cad: null},
+    ],
   },
   {
     type: c.TYPE_DRILL,
@@ -154,7 +154,7 @@ module.exports = [
       {ext: 'txt', cad: [c._CAD_EAGLE_LEGACY, c._CAD_ALTIUM]},
       {
         ext: 'xln',
-        cad: [c._CAD_EAGLE, c._CAD_EAGLE_LEGACY, c._CAD_EAGLE_OSHPARK]
+        cad: [c._CAD_EAGLE, c._CAD_EAGLE_LEGACY, c._CAD_EAGLE_OSHPARK],
       },
       {ext: 'exc', cad: c._CAD_EAGLE_LEGACY},
       {ext: 'drd', cad: c._CAD_EAGLE_LEGACY},
@@ -162,8 +162,8 @@ module.exports = [
       {ext: 'tap', cad: c._CAD_ORCAD},
       {ext: 'fab\\.gbr', cad: c._CAD_GEDA_PCB},
       {ext: 'plated-drill\\.cnc', cad: c._CAD_GEDA_PCB},
-      {match: /npth/, cad: c._CAD_KICAD}
-    ]
+      {match: /npth/, cad: c._CAD_KICAD},
+    ],
   },
   {
     type: c.TYPE_DRAWING,
@@ -172,7 +172,7 @@ module.exports = [
       {ext: 'pos', cad: c._CAD_KICAD},
       {ext: 'gbr', cad: null},
       {ext: 'ger', cad: null},
-      {ext: 'pho', cad: null}
-    ]
-  }
+      {ext: 'pho', cad: null},
+    ],
+  },
 ]

--- a/packages/whats-that-gerber/lib/matchers.js
+++ b/packages/whats-that-gerber/lib/matchers.js
@@ -10,7 +10,7 @@ function layerTypeToMatchers(layer) {
 
   function matcherToCadMatchers(matcher) {
     var match = matcher.ext
-      ? new RegExp(`\\.${matcher.ext}$`, 'i')
+      ? new RegExp('\\.' + matcher.ext + '$', 'i')
       : new RegExp(matcher.match, 'i')
 
     return [].concat(matcher.cad).map(mergeLayerWithCad)

--- a/packages/whats-that-gerber/lib/matchers.js
+++ b/packages/whats-that-gerber/lib/matchers.js
@@ -5,23 +5,23 @@ var layerTypes = require('./layer-types')
 
 module.exports = flatMap(layerTypes, layerTypeToMatchers)
 
-function layerTypeToMatchers (layer) {
+function layerTypeToMatchers(layer) {
   return flatMap(layer.matchers, matcherToCadMatchers)
 
-  function matcherToCadMatchers (matcher) {
+  function matcherToCadMatchers(matcher) {
     var match = matcher.ext
       ? new RegExp(`\\.${matcher.ext}$`, 'i')
       : new RegExp(matcher.match, 'i')
 
     return [].concat(matcher.cad).map(mergeLayerWithCad)
 
-    function mergeLayerWithCad (cad) {
+    function mergeLayerWithCad(cad) {
       return {
         id: layer.id,
         type: layer.type,
         side: layer.side,
         match: match,
-        cad: cad
+        cad: cad,
       }
     }
   }

--- a/packages/whats-that-gerber/test.js
+++ b/packages/whats-that-gerber/test.js
@@ -17,34 +17,34 @@ var EXPECTED_LAYERS = [
   {type: 'copper', side: 'inner'},
   {type: 'outline', side: 'all'},
   {type: 'drill', side: 'all'},
-  {type: 'drawing', side: null}
+  {type: 'drawing', side: null},
 ]
 
-describe('whats-that-gerber', function () {
-  it('should default to null', function () {
+describe('whats-that-gerber', function() {
+  it('should default to null', function() {
     var result = wtg('foobar')
 
     assert.deepEqual(result, {foobar: {side: null, type: null}})
   })
 
-  it('should have a list of all layer types', function () {
+  it('should have a list of all layer types', function() {
     assert.deepEqual(wtg.getAllLayers(), EXPECTED_LAYERS)
   })
 
-  it('should know which types are valid', function () {
+  it('should know which types are valid', function() {
     var allLayers = wtg.getAllLayers()
 
-    allLayers.forEach(function (layer) {
+    allLayers.forEach(function(layer) {
       var result = wtg.validate(layer)
       assert.deepEqual(result, {
         valid: true,
         side: layer.side,
-        type: layer.type
+        type: layer.type,
       })
     })
   })
 
-  it('should know which types are invalid', function () {
+  it('should know which types are invalid', function() {
     var invalidSide = wtg.validate({side: 'bop', type: 'copper'})
     var invalidType = wtg.validate({side: 'top', type: 'topper'})
     var invalidAll = wtg.validate({side: 'fizz', type: 'buzz'})
@@ -54,18 +54,18 @@ describe('whats-that-gerber', function () {
     assert.deepEqual(invalidAll, {valid: false, side: null, type: null})
   })
 
-  cadFilenames.forEach(function (cadSet) {
+  cadFilenames.forEach(function(cadSet) {
     var cad = cadSet.cad
     var files = cadSet.files
 
-    it('should identify ' + cad + ' files', function () {
+    it('should identify ' + cad + ' files', function() {
       var result = wtg(
-        files.map(function (file) {
+        files.map(function(file) {
           return file.name
         })
       )
 
-      files.forEach(function (file) {
+      files.forEach(function(file) {
         var fileResult = result[file.name]
         var sideResult = fileResult.side
         var typeResult = fileResult.type

--- a/packages/whats-that-gerber/test.js
+++ b/packages/whats-that-gerber/test.js
@@ -24,11 +24,11 @@ describe('whats-that-gerber', function() {
   it('should default to null', function() {
     var result = wtg('foobar')
 
-    assert.deepEqual(result, {foobar: {side: null, type: null}})
+    assert.deepStrictEqual(result, {foobar: {side: null, type: null}})
   })
 
   it('should have a list of all layer types', function() {
-    assert.deepEqual(wtg.getAllLayers(), EXPECTED_LAYERS)
+    assert.deepStrictEqual(wtg.getAllLayers(), EXPECTED_LAYERS)
   })
 
   it('should know which types are valid', function() {
@@ -36,7 +36,7 @@ describe('whats-that-gerber', function() {
 
     allLayers.forEach(function(layer) {
       var result = wtg.validate(layer)
-      assert.deepEqual(result, {
+      assert.deepStrictEqual(result, {
         valid: true,
         side: layer.side,
         type: layer.type,
@@ -49,9 +49,13 @@ describe('whats-that-gerber', function() {
     var invalidType = wtg.validate({side: 'top', type: 'topper'})
     var invalidAll = wtg.validate({side: 'fizz', type: 'buzz'})
 
-    assert.deepEqual(invalidSide, {valid: false, side: null, type: 'copper'})
-    assert.deepEqual(invalidType, {valid: false, side: 'top', type: null})
-    assert.deepEqual(invalidAll, {valid: false, side: null, type: null})
+    assert.deepStrictEqual(invalidSide, {
+      valid: false,
+      side: null,
+      type: 'copper',
+    })
+    assert.deepStrictEqual(invalidType, {valid: false, side: 'top', type: null})
+    assert.deepStrictEqual(invalidAll, {valid: false, side: null, type: null})
   })
 
   cadFilenames.forEach(function(cadSet) {
@@ -66,17 +70,18 @@ describe('whats-that-gerber', function() {
       )
 
       files.forEach(function(file) {
-        var fileResult = result[file.name]
+        var name = file.name
+        var fileResult = result[name]
         var sideResult = fileResult.side
         var typeResult = fileResult.type
 
         assert(
           sideResult === file.side,
-          `${file.name} should be side "${file.side}", got "${sideResult}"`
+          name + ' should be side "' + file.side + '", got "' + sideResult + '"'
         )
         assert(
           typeResult === file.type,
-          `${file.name} should be type "${file.type}", got "${typeResult}"`
+          name + ' should be type "' + file.type + '", got "' + typeResult + '"'
         )
       })
     })

--- a/packages/xml-id/index.js
+++ b/packages/xml-id/index.js
@@ -10,19 +10,19 @@ var DEFAULT_RANDOM_LENGTH = 12
 
 module.exports = {
   random: random,
-  sanitize: sanitize
+  sanitize: sanitize,
 }
 
-function random (length) {
+function random(length) {
   length = length || DEFAULT_RANDOM_LENGTH
   return _getRandomString(1, START_CHAR) + _getRandomString(length - 1, CHAR)
 }
 
-function sanitize (source) {
+function sanitize(source) {
   return source.replace(REPLACE_RE, '_')
 }
 
-function _getRandomString (length, alphabet) {
+function _getRandomString(length, alphabet) {
   var abLength = alphabet.length
   var result = ''
 

--- a/packages/xml-id/test.js
+++ b/packages/xml-id/test.js
@@ -3,8 +3,8 @@
 var expect = require('chai').expect
 var xid = require('@tracespace/xml-id')
 
-describe('xml-id', function () {
-  describe('sanitize', function () {
+describe('xml-id', function() {
+  describe('sanitize', function() {
     var SPECS = [
       // should leave these alone
       {given: '_123', expected: '_123'},
@@ -18,14 +18,14 @@ describe('xml-id', function () {
       {given: 'A B C', expected: 'A_B_C'},
       {given: 'A~B~C', expected: 'A_B_C'},
       {given: '.1*2&3', expected: '_1_2_3'},
-      {given: 'abc.def', expected: 'abc_def'}
+      {given: 'abc.def', expected: 'abc_def'},
     ]
 
-    SPECS.forEach(function (spec) {
+    SPECS.forEach(function(spec) {
       var given = spec.given
       var expected = spec.expected
 
-      it('given ' + given + ' expect ' + expected, function () {
+      it('given ' + given + ' expect ' + expected, function() {
         expect(xid.sanitize(given)).to.equal(expected)
       })
     })


### PR DESCRIPTION
This PR removes `prettier-eslint` in favor of a more lightweight prettier + eslint integration. Changes to the setup + advantages:

- Moved eslint config into file
    - Can now extend `standard` while also specifying ES5, so accidental ES6 syntax usage is now caught by the linter
-  Moved prettier config into file
    - Easier to keep track of than magically configuring prettier based on eslint rules
- `eslint` now errors if prettier rules aren't followed
    - Should catch accidentally forgetting to do `npm run format`