### PR TITLE
Added support for excellon drill files w/ leading/trailing set in M71/M72 line

### DIFF
--- a/packages/gerber-parser/lib/_parse-drill.js
+++ b/packages/gerber-parser/lib/_parse-drill.js
@@ -12,7 +12,7 @@ var parseCoord = require('./parse-coord')
 var RE_ALTIUM_HINT = /;FILE_FORMAT=(\d):(\d)/
 var RE_KI_HINT = /;FORMAT={(.):(.)\/ (absolute|.+)? \/ (metric|inch) \/.+(trailing|leading|decimal|keep)/
 
-var RE_UNITS = /(INCH|METRIC)(?:,([TL])Z)?/
+var RE_UNITS = /(INCH|METRIC|M71|M72)(?:,([TL])Z)?/
 var RE_TOOL_DEF = /T0*(\d+)[\S]*C([\d.]+)/
 var RE_TOOL_SET = /T0*(\d+)(?![\S]*C)/
 var RE_COORD = /((?:[XYIJA][+-]?[\d.]+){1,4})(?:G85((?:[XY][+-]?[\d.]+){1,2}))?/
@@ -87,7 +87,7 @@ var parseUnits = function(parser, block, line) {
   var units = unitsMatch[1]
   var suppression = unitsMatch[2]
 
-  if (units === 'METRIC') {
+  if (units === 'METRIC' || units === 'M71') {
     setUnits(parser, 'mm', line)
   } else {
     setUnits(parser, 'in', line)

--- a/packages/gerber-parser/test/gerber-parser_drill_test.js
+++ b/packages/gerber-parser/test/gerber-parser_drill_test.js
@@ -221,17 +221,31 @@ describe('gerber parser with gerber files', function() {
       p.write('METRIC,LZ\n')
       p.end()
       expect(p.format.zero).to.equal('T')
+
+      p = pFactory()
+      p.write('M71,LZ\n')
+      p.end()
+      expect(p.format.zero).to.equal('T')
+
+      p = pFactory()
+      p.write('M72,TZ\n')
+      p.end()
+      expect(p.format.zero).to.equal('L')
     })
 
     it('should not overwrite suppression', function() {
       p.format.zero = 'L'
       p.write('METRIC,LZ\n')
       p.write('INCH,LZ\n')
+      p.write('M72,TZ\n')
+      p.write('M71,TZ\n')
       expect(p.format.zero).to.equal('L')
 
       p.format.zero = 'T'
       p.write('METRIC,TZ\n')
       p.write('INCH,TZ\n')
+      p.write('M72,TZ\n')
+      p.write('M71,TZ\n')
       expect(p.format.zero).to.equal('T')
     })
   })

--- a/packages/gerber-parser/test/gerber-parser_drill_test.js
+++ b/packages/gerber-parser/test/gerber-parser_drill_test.js
@@ -150,6 +150,8 @@ describe('gerber parser with gerber files', function() {
         {type: 'set', line: 2, prop: 'units', value: 'mm'},
         {type: 'set', line: 3, prop: 'units', value: 'in'},
         {type: 'set', line: 4, prop: 'units', value: 'mm'},
+        {type: 'set', line: 5, prop: 'units', value: 'in'},
+        {type: 'set', line: 6, prop: 'units', value: 'mm'},
       ]
 
       expectResults(expected, done)
@@ -157,6 +159,8 @@ describe('gerber parser with gerber files', function() {
       p.write('METRIC\n')
       p.write('INCH,TZ\n')
       p.write('METRIC,LZ\n')
+      p.write('M72,LZ\n')
+      p.write('M71,LZ\n')
       p.end()
     })
 


### PR DESCRIPTION
Ran into a drill file recently that started off like this:
```
M48
M72,LZ
```
I don't know that this is official syntax, but this adds support for files like it.

Note this is completely untested. I started writing tests, but couldn't figure out how to get them to run. It appears there's a bunch of unmarked dependencies required to get a test environment working.