### PR TITLE
chore(deps): Upgrade lerna/codecov to lock new version of har-validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,57 +132,56 @@
       }
     },
     "@lerna/add": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.4.1.tgz",
-      "integrity": "sha512-Vf54B42jlD6G52qnv/cAGH70cVQIa+LX//lfsbkxHvzkhIqBl5J4KsnTOPkA9uq3R+zP58ayicCHB9ReiEWGJg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.6.0.tgz",
+      "integrity": "sha512-aFVekkHMno3hj1Vg3EiIpAwrZ4g34i8z4KrCx7ATY6BRuxVT4Nt/Nk3l2k6gEOq3tWUDtUctLHxIAo14FI8sng==",
       "dev": true,
       "requires": {
-        "@lerna/bootstrap": "^3.4.1",
-        "@lerna/command": "^3.3.0",
-        "@lerna/filter-options": "^3.3.2",
+        "@lerna/bootstrap": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/validation-error": "^3.6.0",
         "dedent": "^0.7.0",
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
         "p-map": "^1.2.0",
-        "pacote": "^9.1.0",
         "semver": "^5.5.0"
       }
     },
     "@lerna/batch-packages": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.1.2.tgz",
-      "integrity": "sha512-HAkpptrYeUVlBYbLScXgeCgk6BsNVXxDd53HVWgzzTWpXV4MHpbpeKrByyt7viXlNhW0w73jJbipb/QlFsHIhQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/batch-packages/-/batch-packages-3.6.0.tgz",
+      "integrity": "sha512-khG15B+EFLH3Oms6A6WsMAy54DrnKIhEAm6CCATN2BKnBkNgitYjLN2vKBzlR2LfQpTkgub67QKIJkMFQcK1Sg==",
       "dev": true,
       "requires": {
-        "@lerna/package-graph": "^3.1.2",
-        "@lerna/validation-error": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yZDJgNm/KDoRH2klzmQGmpWMg/XMzWgeWvauXkrfW/mj1wwmufOuh5pN4fBFxVmUUa/RFZdfMeaaJt3+W3PPBw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.6.0.tgz",
+      "integrity": "sha512-z6rZQw/aLEN+ragWRYqIIVwA9rDv3QtmRc5VyIRrlV/JiuGpq67FcSR6BrCMc/A7UJ9Kx95+bESm/HUwheKoiQ==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/command": "^3.3.0",
-        "@lerna/filter-options": "^3.3.2",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
         "@lerna/has-npm-version": "^3.3.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/npm-install": "^3.3.0",
-        "@lerna/rimraf-dir": "^3.3.0",
-        "@lerna/run-lifecycle": "^3.4.1",
+        "@lerna/npm-install": "^3.6.0",
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/rimraf-dir": "^3.6.0",
+        "@lerna/run-lifecycle": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/symlink-binary": "^3.3.0",
-        "@lerna/symlink-dependencies": "^3.3.0",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/symlink-binary": "^3.6.0",
+        "@lerna/symlink-dependencies": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "dedent": "^0.7.0",
         "get-port": "^3.2.0",
+        "libnpm": "^2.0.1",
         "multimatch": "^2.1.0",
-        "npm-package-arg": "^6.0.0",
-        "npmlog": "^4.1.2",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
         "p-map-series": "^1.0.0",
@@ -192,26 +191,26 @@
       }
     },
     "@lerna/changed": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.4.1.tgz",
-      "integrity": "sha512-gT7fhl4zQWyGETDO4Yy5wsFnqNlBSsezncS1nkMW1uO6jwnolwYqcr1KbrMR8HdmsZBn/00Y0mRnbtbpPPey8w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.6.0.tgz",
+      "integrity": "sha512-L1SXTtQrsv+4F5Knw5sW/nGnMJq+bbOzhZX2srJ10WsuHuzk3cJWAi7dVEsS3RPKUw9DWOuHKy86o3v6byEiqA==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "^3.3.2",
-        "@lerna/command": "^3.3.0",
-        "@lerna/listable": "^3.0.0",
-        "@lerna/output": "^3.0.0",
-        "@lerna/version": "^3.4.1"
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/listable": "^3.6.0",
+        "@lerna/output": "^3.6.0",
+        "@lerna/version": "^3.6.0"
       }
     },
     "@lerna/check-working-tree": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.3.0.tgz",
-      "integrity": "sha512-oeEP1dNhiiKUaO0pmcIi73YXJpaD0n5JczNctvVNZ8fGZmrALZtEnmC28o6Z7JgQaqq5nd2kO7xbnjoitrC51g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.6.0.tgz",
+      "integrity": "sha512-Ioy1t2aVasAwhY1Oi5kfpwbW9RDupxxVVu2t2c1EeBYYCu3jIt1A5ad34gidgsKyiG3HeBEVziI4Uaihnb96ZQ==",
       "dev": true,
       "requires": {
-        "@lerna/describe-ref": "^3.3.0",
-        "@lerna/validation-error": "^3.0.0"
+        "@lerna/describe-ref": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0"
       }
     },
     "@lerna/child-process": {
@@ -252,61 +251,61 @@
       }
     },
     "@lerna/clean": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.3.2.tgz",
-      "integrity": "sha512-mvqusgSp2ou5SGqQgTEoTvGJpGfH4+L6XSeN+Ims+eNFGXuMazmKCf+rz2PZBMFufaHJ/Os+JF0vPCcWI1Fzqg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.6.0.tgz",
+      "integrity": "sha512-4LodI/jh8IEYtqnrY/OFSpWn5YfDWoDv+5QjiJpd91EjW9vjmkvyhzQ5fG9KtltwgYVn/NJ5zlI1WfmMEXvFFQ==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.3.0",
-        "@lerna/filter-options": "^3.3.2",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/rimraf-dir": "^3.3.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/rimraf-dir": "^3.6.0",
         "p-map": "^1.2.0",
         "p-map-series": "^1.0.0",
         "p-waterfall": "^1.0.0"
       }
     },
     "@lerna/cli": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.2.0.tgz",
-      "integrity": "sha512-JdbLyTxHqxUlrkI+Ke+ltXbtyA+MPu9zR6kg/n8Fl6uaez/2fZWtReXzYi8MgLxfUFa7+1OHWJv4eAMZlByJ+Q==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.6.0.tgz",
+      "integrity": "sha512-FGCx7XOLpqmU5eFOlo0Lt0hRZraxSUTEWM0bce0p+HNpOxBc91o6d2tenW1azPYFP9HzsMQey1NBtU0ofJJeog==",
       "dev": true,
       "requires": {
         "@lerna/global-options": "^3.1.3",
         "dedent": "^0.7.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "yargs": "^12.0.1"
       }
     },
     "@lerna/collect-updates": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.3.2.tgz",
-      "integrity": "sha512-9WyBJI2S5sYgEZEScu525Lbi6nknNrdBKop35sCDIC9y6AIGvH6Dr5tkTd+Kg3n1dE+kHwW/xjERkx3+h7th3w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.6.0.tgz",
+      "integrity": "sha512-knliEz3phY51SGnwDhhYqx6SJN6y9qh/gZrZgQ7ogqz1UgA/MyJb27gszjsyyG6jUQshimBpjsG7OMwjt8+n9A==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/describe-ref": "^3.3.0",
+        "@lerna/describe-ref": "^3.6.0",
+        "libnpm": "^2.0.1",
         "minimatch": "^3.0.4",
-        "npmlog": "^4.1.2",
         "slash": "^1.0.0"
       }
     },
     "@lerna/command": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.3.0.tgz",
-      "integrity": "sha512-NTOkLEKlWcBLHSvUr9tzVpV7RJ4GROLeOuZ6RfztGOW/31JPSwVVBD2kPifEXNZunldOx5GVWukR+7+NpAWhsg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.6.0.tgz",
+      "integrity": "sha512-BGpXaY2WrxPcIiZX0aATO2HQBatvYT7Qy46lqMnV9RrTePYJ1PPbX1nMzLXSxgrnnlTcTwJNEkw/TL9Xzrph7Q==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/package-graph": "^3.1.2",
-        "@lerna/project": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0",
-        "@lerna/write-log-file": "^3.0.0",
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/project": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
+        "@lerna/write-log-file": "^3.6.0",
         "dedent": "^0.7.0",
         "execa": "^1.0.0",
         "is-ci": "^1.0.10",
-        "lodash": "^4.17.5",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1",
+        "lodash": "^4.17.5"
       },
       "dependencies": {
         "execa": {
@@ -336,19 +335,18 @@
       }
     },
     "@lerna/conventional-commits": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.4.1.tgz",
-      "integrity": "sha512-3NETrA58aUkaEW3RdwdJ766Bg9NVpLzb26mtdlsJQcvB5sQBWH5dJSHIVQH1QsGloBeH2pE/mDUEVY8ZJXuR4w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.6.0.tgz",
+      "integrity": "sha512-KkY3wd7w/tj76EEIhTMYZlSBk/5WkT2NA9Gr/EuSwKV70PYyVA55l1OGlikBUAnuqIjwyfw9x3y+OcbYI4aNEg==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.0.0",
-        "conventional-changelog-angular": "^5.0.1",
-        "conventional-changelog-core": "^3.1.0",
-        "conventional-recommended-bump": "^4.0.1",
+        "@lerna/validation-error": "^3.6.0",
+        "conventional-changelog-angular": "^5.0.2",
+        "conventional-changelog-core": "^3.1.5",
+        "conventional-recommended-bump": "^4.0.4",
         "fs-extra": "^7.0.0",
         "get-stream": "^4.0.0",
-        "npm-package-arg": "^6.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "semver": "^5.5.0"
       },
       "dependencies": {
@@ -364,21 +362,22 @@
       }
     },
     "@lerna/create": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.4.1.tgz",
-      "integrity": "sha512-l+4t2SRO5nvW0MNYY+EWxbaMHsAN8bkWH3nyt7EzhBjs4+TlRAJRIEqd8o9NWznheE3pzwczFz1Qfl3BWbyM5A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.6.0.tgz",
+      "integrity": "sha512-21OunW25Y3Q/oynqWVk0znQFBvZ5tHyLPhzkJeomGmOj0il1RdOUiChu9G9AYsCaLDwBFR0ZFqvTgJ5iw/eaIg==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.3.0",
+        "@lerna/command": "^3.6.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/validation-error": "^3.6.0",
         "camelcase": "^4.1.0",
         "dedent": "^0.7.0",
         "fs-extra": "^7.0.0",
         "globby": "^8.0.1",
         "init-package-json": "^1.10.3",
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
+        "p-reduce": "^1.0.0",
         "pify": "^3.0.0",
         "semver": "^5.5.0",
         "slash": "^1.0.0",
@@ -396,81 +395,81 @@
       }
     },
     "@lerna/create-symlink": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.3.0.tgz",
-      "integrity": "sha512-0lb88Nnq1c/GG+fwybuReOnw3+ah4dB81PuWwWwuqUNPE0n50qUf/M/7FfSb5JEh/93fcdbZI0La8t3iysNW1w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.6.0.tgz",
+      "integrity": "sha512-YG3lTb6zylvmGqKU+QYA3ylSnoLn+FyLH5XZmUsD0i85R884+EyJJeHx/zUk+yrL2ZwHS4RBUgJfC24fqzgPoA==",
       "dev": true,
       "requires": {
         "cmd-shim": "^2.0.2",
         "fs-extra": "^7.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/describe-ref": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.3.0.tgz",
-      "integrity": "sha512-4t7M4OupnYMSPNLrLUau8qkS+dgLEi4w+DkRkV0+A+KNYga1W0jVgNLPIIsxta7OHfodPkCNAqZCzNCw/dmAwA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.6.0.tgz",
+      "integrity": "sha512-hVZJ2hYVbrrNiEG+dEg/Op4pYAbROkDZdiIUabAJffr0T/frcN+5es2HfmOC//4+78Cs1M9iTyQRoyC1RXS2BQ==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/diff": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha512-sIoMjsm3NVxvmt6ofx8Uu/2fxgldQqLl0zmC9X1xW00j831o5hBffx1EoKj9CnmaEvoSP6j/KFjxy2RWjebCIg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.6.0.tgz",
+      "integrity": "sha512-p5+VyYKuAnw6NFVrT4s9eBubFZEYlJmiR1mdVlwNtohqS86gERjrPtI0unUK/pxFKb1U2ZNo4fhSlPd+pLwfHg==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.3.0",
-        "@lerna/validation-error": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "@lerna/command": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/exec": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.3.2.tgz",
-      "integrity": "sha512-mN6vGxNir7JOGvWLwKr3DW3LNy1ecCo2ziZj5rO9Mw5Rew3carUu1XLmhF/4judtsvXViUY+rvGIcqHe0vvb+w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.6.0.tgz",
+      "integrity": "sha512-lwLYASpS8FoQpVYLBpoZlS7bpzkO9pD3D9XeDDKZBodDhdZeCEx2Md2CxZU1RKYDSVIXA8oObvlUh1FEhRQv2w==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
+        "@lerna/batch-packages": "^3.6.0",
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.3.0",
-        "@lerna/filter-options": "^3.3.2",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0"
+        "@lerna/validation-error": "^3.6.0"
       }
     },
     "@lerna/filter-options": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.3.2.tgz",
-      "integrity": "sha512-0WHqdDgAnt5WKoByi1q+lFw8HWt5tEKP2DnLlGqWv3YFwVF5DsPRlO7xbzjY9sJgvyJtZcnkMtccdBPFhGGyIQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.6.0.tgz",
+      "integrity": "sha512-6iUMZuvvXPL5EAF7Zo9azaZ6FxOq6tGbiSX8fUXgCdN+jlRjorvkzR+E0HS4bEGTWmV446lnLwdQLZuySfLcbQ==",
       "dev": true,
       "requires": {
-        "@lerna/collect-updates": "^3.3.2",
-        "@lerna/filter-packages": "^3.0.0",
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/filter-packages": "^3.6.0",
         "dedent": "^0.7.0"
       }
     },
     "@lerna/filter-packages": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.0.0.tgz",
-      "integrity": "sha512-zwbY1J4uRjWRZ/FgYbtVkq7I3Nduwsg2V2HwLKSzwV2vPglfGqgovYOVkND6/xqe2BHwDX4IyA2+e7OJmLaLSA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.6.0.tgz",
+      "integrity": "sha512-O/nIENV3LOqp/TiUIw3Ir6L/wUGFDeYBdJsJTQDlTAyHZsgYA1OIn9FvlW8nqBu1bNLzoBVHXh3c5azx1kE+Hg==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.0.0",
-        "multimatch": "^2.1.0",
-        "npmlog": "^4.1.2"
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1",
+        "multimatch": "^2.1.0"
       }
     },
     "@lerna/get-npm-exec-opts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.0.0.tgz",
-      "integrity": "sha512-arcYUm+4xS8J3Palhl+5rRJXnZnFHsLFKHBxznkPIxjwGQeAEw7df38uHdVjEQ+HNeFmHnBgSqfbxl1VIw5DHg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/get-npm-exec-opts/-/get-npm-exec-opts-3.6.0.tgz",
+      "integrity": "sha512-ruH6KuLlt75aCObXfUIdVJqmfVq7sgWGq5mXa05vc1MEqxTIiU23YiJdWzofQOOUOACaZkzZ4K4Nu7wXEg4Xgg==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/global-options": {
@@ -490,78 +489,79 @@
       }
     },
     "@lerna/import": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.3.1.tgz",
-      "integrity": "sha512-2OzTQDkYKbBPpyP2iOI1sWfcvMjNLjjHjmREq/uOWJaSIk5J3Ukt71OPpcOHh4V2CBOlXidCcO+Hyb4FVIy8fw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.6.0.tgz",
+      "integrity": "sha512-8jxNRbAaa4mvMJr0u+sy75gMFPyWfxLHEp+pDs73x1oqMZhpS8O5901QMnpZyRyOvJRhoBJd5hBX2dpsLxC6Xw==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.3.0",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "dedent": "^0.7.0",
         "fs-extra": "^7.0.0",
         "p-map-series": "^1.0.0"
       }
     },
     "@lerna/init": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.3.0.tgz",
-      "integrity": "sha512-HvgRLkIG6nDIeAO6ix5sUVIVV+W9UMk2rSSmFT66CDOefRi7S028amiyYnFUK1QkIAaUbVUyOnYaErtbJwICuw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.6.0.tgz",
+      "integrity": "sha512-MTLy3rmMdvpXRmDdoYiVPx7I8sXH4dquq/0MxntL5VxSVh/ZS1HsbrjyRqpdkUKWD9QguxR/w0pzOjVvCeM8CQ==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/command": "^3.3.0",
+        "@lerna/command": "^3.6.0",
         "fs-extra": "^7.0.0",
         "p-map": "^1.2.0",
         "write-json-file": "^2.3.0"
       }
     },
     "@lerna/link": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.3.0.tgz",
-      "integrity": "sha512-8CeXzGL7okrsVXsy2sHXI2KuBaczw3cblAnA2+FJPUqSKMPNbUTRzeU3bOlCjYtK0LbxC4ngENJTL3jJ8RaYQQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.6.0.tgz",
+      "integrity": "sha512-Xk8TTAE4EWGyhxLuPxWdyS7i7vfsM5igb6tEyhZm94XUdlA4PmMOYe25BfO7SM/9LYroFknZeDyWAebye3r+PA==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.3.0",
-        "@lerna/package-graph": "^3.1.2",
-        "@lerna/symlink-dependencies": "^3.3.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/package-graph": "^3.6.0",
+        "@lerna/symlink-dependencies": "^3.6.0",
         "p-map": "^1.2.0",
         "slash": "^1.0.0"
       }
     },
     "@lerna/list": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.3.2.tgz",
-      "integrity": "sha512-XXEVy7w+i/xx8NeJmGirw4upEoEF9OfD6XPLjISNQc24VgQV+frXdVJ02QcP7Y/PkY1rdIVrOjvo3ipKVLUxaQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.6.0.tgz",
+      "integrity": "sha512-hlQOJkg8K3XXUVXotofP71XsgkhXkkmU/EkqlNg15D78MjzhT+p1wCbG5m89K3tzvjcWVeZwU6L0elaOIXVyCw==",
       "dev": true,
       "requires": {
-        "@lerna/command": "^3.3.0",
-        "@lerna/filter-options": "^3.3.2",
-        "@lerna/listable": "^3.0.0",
-        "@lerna/output": "^3.0.0"
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
+        "@lerna/listable": "^3.6.0",
+        "@lerna/output": "^3.6.0"
       }
     },
     "@lerna/listable": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.0.0.tgz",
-      "integrity": "sha512-HX/9hyx1HLg2kpiKXIUc1EimlkK1T58aKQ7ovO7rQdTx9ForpefoMzyLnHE1n4XrUtEszcSWJIICJ/F898M6Ag==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.6.0.tgz",
+      "integrity": "sha512-fz63+zlqrJ9KQxIiv0r7qtufM4DEinSayAuO8YJuooz+1ctIP7RvMEQNvYI/E9tDlUo9Q0de68b5HbKrpmA5rQ==",
       "dev": true,
       "requires": {
+        "@lerna/batch-packages": "^3.6.0",
         "chalk": "^2.3.1",
         "columnify": "^1.5.4"
       }
     },
     "@lerna/log-packed": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.0.4.tgz",
-      "integrity": "sha512-vVQHgMagE2wnbxhNY9nFkdu+Cx2TsyWalkJfkxbNzmo6gOCrDsxCBDj9vTEV8Q+4aWx0C0Bsc0sB2Eb8y/+ofA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.6.0.tgz",
+      "integrity": "sha512-T/J41zMkzpWB5nbiTRS5PmYTFn74mJXe6RQA2qhkdLi0UqnTp97Pux1loz3jsJf2yJtiQUnyMM7KuKIAge0Vlw==",
       "dev": true,
       "requires": {
         "byte-size": "^4.0.3",
         "columnify": "^1.5.4",
         "has-unicode": "^2.0.1",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/npm-conf": {
@@ -583,102 +583,100 @@
       }
     },
     "@lerna/npm-dist-tag": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.3.0.tgz",
-      "integrity": "sha512-EtZJXzh3w5tqXEev+EBBPrWKWWn0WgJfxm4FihfS9VgyaAW8udIVZHGkIQ3f+tBtupcAzA9Q8cQNUkGF2efwmA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.6.0.tgz",
+      "integrity": "sha512-qX6IfQPX9Tum1LRjvjgj/yr2FYbc9dfHyeh7RI9zJ8pGncWbksBmnMcvoxF0Eu4+d7MjjIGfEnIp9LIl4MHSIA==",
       "dev": true,
       "requires": {
-        "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1",
+        "npm-registry-fetch": "^3.8.0"
       }
     },
     "@lerna/npm-install": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.3.0.tgz",
-      "integrity": "sha512-WoVvKdS8ltROTGSNQwo6NDq0YKnjwhvTG4li1okcN/eHKOS3tL9bxbgPx7No0wOq5DKBpdeS9KhAfee6LFAZ5g==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.6.0.tgz",
+      "integrity": "sha512-RKV31VdrBZKjmKfq25JG4mIHJ8NAOsLKq/aYSaBs8zP+uwXH7RU39saVfv9ReKiAzhKE2ghOG2JeMdIHtYnPNA==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
+        "@lerna/get-npm-exec-opts": "^3.6.0",
         "fs-extra": "^7.0.0",
-        "npm-package-arg": "^6.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "signal-exit": "^3.0.2",
         "write-pkg": "^3.1.0"
       }
     },
     "@lerna/npm-publish": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.3.1.tgz",
-      "integrity": "sha512-bVTlWIcBL6Zpyzqvr9C7rxXYcoPw+l7IPz5eqQDNREj1R39Wj18OWB2KTJq8l7LIX7Wf4C2A1uT5hJaEf9BuvA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.6.0.tgz",
+      "integrity": "sha512-k4yF8ursajoGRlJeRh7xdeGN0HV/ALt5qImUnpTliux0213jqxA0YigiD8WSaXpvSqxSFyvh38DbJhhy9q+NuQ==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
+        "@lerna/get-npm-exec-opts": "^3.6.0",
         "@lerna/has-npm-version": "^3.3.0",
-        "@lerna/log-packed": "^3.0.4",
+        "@lerna/log-packed": "^3.6.0",
         "fs-extra": "^7.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "p-map": "^1.2.0"
       }
     },
     "@lerna/npm-run-script": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.3.0.tgz",
-      "integrity": "sha512-YqDguWZzp4jIomaE4aWMUP7MIAJAFvRAf6ziQLpqwoQskfWLqK5mW0CcszT1oLjhfb3cY3MMfSTFaqwbdKmICg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.6.0.tgz",
+      "integrity": "sha512-6DRNFma30ex9r1a8mMDXziSRHf1/mo//hnvW1Zc1ctBh+7PU4I8n3A2ht/+742vtoTQH93Iqs3QSJl2KOLSsYg==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
-        "npmlog": "^4.1.2"
+        "@lerna/get-npm-exec-opts": "^3.6.0",
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/output": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.0.0.tgz",
-      "integrity": "sha512-EFxnSbO0zDEVKkTKpoCUAFcZjc3gn3DwPlyTDxbeqPU7neCfxP4rA4+0a6pcOfTlRS5kLBRMx79F2TRCaMM3DA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/output/-/output-3.6.0.tgz",
+      "integrity": "sha512-9sjQouf6p7VQtVCRnzoTGlZyURd48i3ha3WBHC/UBJnHZFuXMqWVPKNuvnMf2kRXDyoQD+2mNywpmEJg5jOnRg==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/package": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.0.0.tgz",
-      "integrity": "sha512-djzEJxzn212wS8d9znBnlXkeRlPL7GqeAYBykAmsuq51YGvaQK67Umh5ejdO0uxexF/4r7yRwgrlRHpQs8Rfqg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.6.0.tgz",
+      "integrity": "sha512-XbXcjwPKA1V640mqjEicpBriO6QcNtocdfLAtEUP4uCKkRx5r9h7DdznQMCoSJYJF6Gh/PpLokPUItfMhJP3Hg==",
       "dev": true,
       "requires": {
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
         "write-pkg": "^3.1.0"
       }
     },
     "@lerna/package-graph": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.1.2.tgz",
-      "integrity": "sha512-9wIWb49I1IJmyjPdEVZQ13IAi9biGfH/OZHOC04U2zXGA0GLiY+B3CAx6FQvqkZ8xEGfqzmXnv3LvZ0bQfc1aQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.6.0.tgz",
+      "integrity": "sha512-Xtldh3DTiC3cPDrs6OY5URiuRXGPMIN6uFKcx59rOu3TkqYRt346jRyX+hm85996Y/pboo3+JuQlonvuEP/9QQ==",
       "dev": true,
       "requires": {
-        "@lerna/validation-error": "^3.0.0",
-        "npm-package-arg": "^6.0.0",
+        "@lerna/validation-error": "^3.6.0",
+        "libnpm": "^2.0.1",
         "semver": "^5.5.0"
       }
     },
     "@lerna/project": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.0.0.tgz",
-      "integrity": "sha512-XhDFVfqj79jG2Speggd15RpYaE8uiR25UKcQBDmumbmqvTS7xf2cvl2pq2UTvDafaJ0YwFF3xkxQZeZnFMwdkw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.6.0.tgz",
+      "integrity": "sha512-pEOZF1igGFqs+qWog6cJWqVyBUX21xSqrlcgeN0yzqzI36VMHozmf/u7dgclIb5MylWk5Yp87KCKswBF4hrcuQ==",
       "dev": true,
       "requires": {
-        "@lerna/package": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/package": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "cosmiconfig": "^5.0.2",
         "dedent": "^0.7.0",
         "dot-prop": "^4.2.0",
         "glob-parent": "^3.1.0",
         "globby": "^8.0.1",
+        "libnpm": "^2.0.1",
         "load-json-file": "^4.0.0",
-        "npmlog": "^4.1.2",
         "p-map": "^1.2.0",
         "resolve-from": "^4.0.0",
         "write-json-file": "^2.3.0"
@@ -711,42 +709,40 @@
       }
     },
     "@lerna/prompt": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.3.1.tgz",
-      "integrity": "sha512-eJhofrUCUaItMIH6et8kI7YqHfhjWqGZoTsE+40NRCfAraOMWx+pDzfRfeoAl3qeRAH2HhNj1bkYn70FbUOxuQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.6.0.tgz",
+      "integrity": "sha512-nyAjPMolJ/ZRAAVcXrUH89C4n1SiWvLh4xWNvWYKLcf3PI5yges35sDFP/HYrM4+cEbkNFuJCRq6CxaET4PRsg==",
       "dev": true,
       "requires": {
         "inquirer": "^6.2.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/publish": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.4.3.tgz",
-      "integrity": "sha512-baeRL8xmOR25p86cAaS9mL0jdRzdv4dUo04PlK2Wes+YlL705F55cSXeC9npNie+9rGwFyLzCTQe18WdbZyLuw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.6.0.tgz",
+      "integrity": "sha512-F2bT96ZS7NJfid6T4a6TSanpVUQ4VOuhjPBPX2hagt5gnocm7lluvAFR7dl/cbEgmKIg2zJQnfAPTYjrtxXMVg==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/check-working-tree": "^3.3.0",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/check-working-tree": "^3.6.0",
         "@lerna/child-process": "^3.3.0",
-        "@lerna/collect-updates": "^3.3.2",
-        "@lerna/command": "^3.3.0",
-        "@lerna/describe-ref": "^3.3.0",
-        "@lerna/get-npm-exec-opts": "^3.0.0",
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/describe-ref": "^3.6.0",
+        "@lerna/get-npm-exec-opts": "^3.6.0",
         "@lerna/npm-conf": "^3.4.1",
-        "@lerna/npm-dist-tag": "^3.3.0",
-        "@lerna/npm-publish": "^3.3.1",
-        "@lerna/output": "^3.0.0",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/run-lifecycle": "^3.4.1",
+        "@lerna/npm-dist-tag": "^3.6.0",
+        "@lerna/npm-publish": "^3.6.0",
+        "@lerna/output": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/run-lifecycle": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0",
-        "@lerna/version": "^3.4.1",
+        "@lerna/validation-error": "^3.6.0",
+        "@lerna/version": "^3.6.0",
         "fs-extra": "^7.0.0",
-        "libnpmaccess": "^3.0.0",
-        "npm-package-arg": "^6.0.0",
+        "libnpm": "^2.0.1",
         "npm-registry-fetch": "^3.8.0",
-        "npmlog": "^4.1.2",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
         "p-pipe": "^1.2.0",
@@ -755,53 +751,53 @@
       }
     },
     "@lerna/resolve-symlink": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.3.0.tgz",
-      "integrity": "sha512-KmoPDcFJ2aOK2inYHbrsiO9SodedUj0L1JDvDgirVNIjMUaQe2Q6Vi4Gh+VCJcyB27JtfHioV9R2NxU72Pk2hg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.6.0.tgz",
+      "integrity": "sha512-TVOAEqHJSQVhNDMFCwEUZPaOETqHDQV1TQWQfC8ZlOqyaUQ7veZUbg0yfG7RPNzlSpvF0ZaGFeR0YhYDAW03GA==",
       "dev": true,
       "requires": {
         "fs-extra": "^7.0.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "read-cmd-shim": "^1.0.1"
       }
     },
     "@lerna/rimraf-dir": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.3.0.tgz",
-      "integrity": "sha512-vSqOcZ4kZduiSprbt+y40qziyN3VKYh+ygiCdnbBbsaxpdKB6CfrSMUtrLhVFrqUfBHIZRzHIzgjTdtQex1KLw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.6.0.tgz",
+      "integrity": "sha512-2CfyWP1lqxDET+SfwGlLUfgqGF4vz9TYDrmb7Zi//g7IFCo899uU2vWOrEcdWTgbKE3Qgwwfk9c008w5MWUhog==",
       "dev": true,
       "requires": {
         "@lerna/child-process": "^3.3.0",
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "path-exists": "^3.0.0",
         "rimraf": "^2.6.2"
       }
     },
     "@lerna/run": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.3.2.tgz",
-      "integrity": "sha512-cruwRGZZWnQ5I0M+AqcoT3Xpq2wj3135iVw4n59/Op6dZu50sMFXZNLiTTTZ15k8rTKjydcccJMdPSpTHbH7/A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.6.0.tgz",
+      "integrity": "sha512-OYa5pQTOiES/h9rg8vwnt0nYU/wLKUQmFYhMUxdX3lXYpoIcQ28PR7qPG1CVhex4KAU2OW42a7vnm5MAOoScDg==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/command": "^3.3.0",
-        "@lerna/filter-options": "^3.3.2",
-        "@lerna/npm-run-script": "^3.3.0",
-        "@lerna/output": "^3.0.0",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/filter-options": "^3.6.0",
+        "@lerna/npm-run-script": "^3.6.0",
+        "@lerna/output": "^3.6.0",
         "@lerna/run-parallel-batches": "^3.0.0",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/timer": "^3.5.0",
+        "@lerna/validation-error": "^3.6.0",
         "p-map": "^1.2.0"
       }
     },
     "@lerna/run-lifecycle": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.4.1.tgz",
-      "integrity": "sha512-N/hi2srM9A4BWEkXccP7vCEbf4MmIuALF00DTBMvc0A/ccItwUpl3XNuM7+ADDRK0mkwE3hDw89lJ3A7f8oUQw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.6.0.tgz",
+      "integrity": "sha512-/1+vAZnckgKwHVgWG0plVO24erNWUduz9htMOO9wuOfglTnHlMRqDc3s9B/OIKxGDkyzEvxqzfzq3c6JqEolRQ==",
       "dev": true,
       "requires": {
         "@lerna/npm-conf": "^3.4.1",
-        "npm-lifecycle": "^2.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/run-parallel-batches": {
@@ -815,13 +811,13 @@
       }
     },
     "@lerna/symlink-binary": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.3.0.tgz",
-      "integrity": "sha512-zRo6CimhvH/VJqCFl9T4IC6syjpWyQIxEfO2sBhrapEcfwjtwbhoGgKwucsvt4rIpFazCw63jQ/AXMT27KUIHg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.6.0.tgz",
+      "integrity": "sha512-h69AQBBWgZOEzQ1RJEYQ7Ou6llrJNhNNkpqT6k8qSWZ93iXyFmLE4hWoxMXXHFmxmQ0CqjEYKmeLV1Dr5DKT4g==",
       "dev": true,
       "requires": {
-        "@lerna/create-symlink": "^3.3.0",
-        "@lerna/package": "^3.0.0",
+        "@lerna/create-symlink": "^3.6.0",
+        "@lerna/package": "^3.6.0",
         "fs-extra": "^7.0.0",
         "p-map": "^1.2.0",
         "read-pkg": "^3.0.0"
@@ -859,49 +855,55 @@
       }
     },
     "@lerna/symlink-dependencies": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.3.0.tgz",
-      "integrity": "sha512-IRngSNCmuD5uBKVv23tHMvr7Mplti0lKHilFKcvhbvhAfu6m/Vclxhkfs/uLyHzG+DeRpl/9o86SQET3h4XDhg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.6.0.tgz",
+      "integrity": "sha512-mLpbWLidAU5Xi7bc9Fj8Yt/9XvDczzWocnS/yEe0E6RqWXh2KK+4VR9H24rLywBAWTv2s4GEXrb/ofbPb8gwBQ==",
       "dev": true,
       "requires": {
-        "@lerna/create-symlink": "^3.3.0",
-        "@lerna/resolve-symlink": "^3.3.0",
-        "@lerna/symlink-binary": "^3.3.0",
+        "@lerna/create-symlink": "^3.6.0",
+        "@lerna/resolve-symlink": "^3.6.0",
+        "@lerna/symlink-binary": "^3.6.0",
         "fs-extra": "^7.0.0",
         "p-finally": "^1.0.0",
         "p-map": "^1.2.0",
         "p-map-series": "^1.0.0"
       }
     },
+    "@lerna/timer": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@lerna/timer/-/timer-3.5.0.tgz",
+      "integrity": "sha512-TAb99hqQN6E3JBGtG9iyZNPq1/DbmqgBOeNrKtdJsGvIeX/NGLgUDWMrj2h04V4O+jpBFmSf6HIld6triKmxCA==",
+      "dev": true
+    },
     "@lerna/validation-error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.0.0.tgz",
-      "integrity": "sha512-5wjkd2PszV0kWvH+EOKZJWlHEqCTTKrWsvfHnHhcUaKBe/NagPZFWs+0xlsDPZ3DJt5FNfbAPAnEBQ05zLirFA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/validation-error/-/validation-error-3.6.0.tgz",
+      "integrity": "sha512-MWltncGO5VgMS0QedTlZCjFUMF/evRjDMMHrtVorkIB2Cp5xy0rkKa8iDBG43qpUWeG1giwi58yUlETBcWfILw==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "@lerna/version": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.4.1.tgz",
-      "integrity": "sha512-oefNaQLBJSI2WLZXw5XxDXk4NyF5/ct0V9ys/J308NpgZthPgwRPjk9ZR0o1IOxW1ABi6z3E317W/dxHDjvAkg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.6.0.tgz",
+      "integrity": "sha512-V1f3fNM5ELGHmF824Wc8ah505SMpfiBqOHAIiW+u9soH/3W/t256c1P9UeaDh5blWAk3HeZMzbpRZ9Nlpf6aQA==",
       "dev": true,
       "requires": {
-        "@lerna/batch-packages": "^3.1.2",
-        "@lerna/check-working-tree": "^3.3.0",
+        "@lerna/batch-packages": "^3.6.0",
+        "@lerna/check-working-tree": "^3.6.0",
         "@lerna/child-process": "^3.3.0",
-        "@lerna/collect-updates": "^3.3.2",
-        "@lerna/command": "^3.3.0",
-        "@lerna/conventional-commits": "^3.4.1",
-        "@lerna/output": "^3.0.0",
-        "@lerna/prompt": "^3.3.1",
-        "@lerna/run-lifecycle": "^3.4.1",
-        "@lerna/validation-error": "^3.0.0",
+        "@lerna/collect-updates": "^3.6.0",
+        "@lerna/command": "^3.6.0",
+        "@lerna/conventional-commits": "^3.6.0",
+        "@lerna/output": "^3.6.0",
+        "@lerna/prompt": "^3.6.0",
+        "@lerna/run-lifecycle": "^3.6.0",
+        "@lerna/validation-error": "^3.6.0",
         "chalk": "^2.3.1",
         "dedent": "^0.7.0",
+        "libnpm": "^2.0.1",
         "minimatch": "^3.0.4",
-        "npmlog": "^4.1.2",
         "p-map": "^1.2.0",
         "p-pipe": "^1.2.0",
         "p-reduce": "^1.0.0",
@@ -912,12 +914,12 @@
       }
     },
     "@lerna/write-log-file": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.0.0.tgz",
-      "integrity": "sha512-SfbPp29lMeEVOb/M16lJwn4nnx5y+TwCdd7Uom9umd7KcZP0NOvpnX0PHehdonl7TyHZ1Xx2maklYuCLbQrd/A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lerna/write-log-file/-/write-log-file-3.6.0.tgz",
+      "integrity": "sha512-OkLK99V6sYXsJsYg+O9wtiFS3z6eUPaiz2e6cXJt80mfIIdI1t2dnmyua0Ib5cZWExQvx2z6Y32Wlf0MnsoNsA==",
       "dev": true,
       "requires": {
-        "npmlog": "^4.1.2",
+        "libnpm": "^2.0.1",
         "write-file-atomic": "^2.3.0"
       }
     },
@@ -1465,6 +1467,19 @@
         "callsite": "1.0.0"
       }
     },
+    "bin-links": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-1.1.2.tgz",
+      "integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.0",
+        "cmd-shim": "^2.0.2",
+        "gentle-fs": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -1854,9 +1869,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -4155,6 +4170,12 @@
         }
       }
     },
+    "find-npm-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz",
+      "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
+      "dev": true
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -4298,6 +4319,17 @@
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
+      }
+    },
+    "fs-vacuum": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.10.tgz",
+      "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "path-is-inside": "^1.0.1",
+        "rimraf": "^2.5.2"
       }
     },
     "fs-write-stream-atomic": {
@@ -4903,7 +4935,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -4928,6 +4960,22 @@
       "resolved": "https://registry.npmjs.org/genfun/-/genfun-5.0.0.tgz",
       "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
       "dev": true
+    },
+    "gentle-fs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gentle-fs/-/gentle-fs-2.0.1.tgz",
+      "integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.2",
+        "fs-vacuum": "^1.2.10",
+        "graceful-fs": "^4.1.11",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "path-is-inside": "^1.0.2",
+        "read-cmd-shim": "^1.0.1",
+        "slide": "^1.1.6"
+      }
     },
     "gerber-parser": {
       "version": "file:packages/gerber-parser",
@@ -5388,9 +5436,9 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",
@@ -6458,28 +6506,28 @@
       }
     },
     "lerna": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.4.3.tgz",
-      "integrity": "sha512-tWq1LvpHqkyB+FaJCmkEweivr88yShDMmauofPVdh0M5gU1cVucszYnIgWafulKYu2LMQ3IfUMUU5Pp3+MvADQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.6.0.tgz",
+      "integrity": "sha512-iQFAgrgtv18SI5LtQBBca0WVeYvk2r8eYgiEQtcZBT63T5R9RVv+snsviIiOp0z6gD43tcyiWXiLvBdp1IY/Rg==",
       "dev": true,
       "requires": {
-        "@lerna/add": "^3.4.1",
-        "@lerna/bootstrap": "^3.4.1",
-        "@lerna/changed": "^3.4.1",
-        "@lerna/clean": "^3.3.2",
-        "@lerna/cli": "^3.2.0",
-        "@lerna/create": "^3.4.1",
-        "@lerna/diff": "^3.3.0",
-        "@lerna/exec": "^3.3.2",
-        "@lerna/import": "^3.3.1",
-        "@lerna/init": "^3.3.0",
-        "@lerna/link": "^3.3.0",
-        "@lerna/list": "^3.3.2",
-        "@lerna/publish": "^3.4.3",
-        "@lerna/run": "^3.3.2",
-        "@lerna/version": "^3.4.1",
+        "@lerna/add": "^3.6.0",
+        "@lerna/bootstrap": "^3.6.0",
+        "@lerna/changed": "^3.6.0",
+        "@lerna/clean": "^3.6.0",
+        "@lerna/cli": "^3.6.0",
+        "@lerna/create": "^3.6.0",
+        "@lerna/diff": "^3.6.0",
+        "@lerna/exec": "^3.6.0",
+        "@lerna/import": "^3.6.0",
+        "@lerna/init": "^3.6.0",
+        "@lerna/link": "^3.6.0",
+        "@lerna/list": "^3.6.0",
+        "@lerna/publish": "^3.6.0",
+        "@lerna/run": "^3.6.0",
+        "@lerna/version": "^3.6.0",
         "import-local": "^1.0.0",
-        "npmlog": "^4.1.2"
+        "libnpm": "^2.0.1"
       }
     },
     "levn": {
@@ -6492,15 +6540,197 @@
         "type-check": "~0.3.2"
       }
     },
+    "libnpm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/libnpm/-/libnpm-2.0.1.tgz",
+      "integrity": "sha512-qTKoxyJvpBxHZQB6k0AhSLajyXq9ZE/lUsZzuHAplr2Bpv9G+k4YuYlExYdUCeVRRGqcJt8hvkPh4tBwKoV98w==",
+      "dev": true,
+      "requires": {
+        "bin-links": "^1.1.2",
+        "bluebird": "^3.5.3",
+        "find-npm-prefix": "^1.0.2",
+        "libnpmaccess": "^3.0.1",
+        "libnpmconfig": "^1.2.1",
+        "libnpmhook": "^5.0.2",
+        "libnpmorg": "^1.0.0",
+        "libnpmpublish": "^1.1.0",
+        "libnpmsearch": "^2.0.0",
+        "libnpmteam": "^1.0.1",
+        "lock-verify": "^2.0.2",
+        "npm-lifecycle": "^2.1.0",
+        "npm-logical-tree": "^1.2.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-profile": "^4.0.1",
+        "npm-registry-fetch": "^3.8.0",
+        "npmlog": "^4.1.2",
+        "pacote": "^9.2.3",
+        "read-package-json": "^2.0.13",
+        "stringify-package": "^1.0.0"
+      }
+    },
     "libnpmaccess": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.0.tgz",
-      "integrity": "sha512-SiE4AZAzMpD7pmmXHfgD7rof8QIQGoKaeyAS8exgx2CKA6tzRTbRljq1xM4Tgj8/tIg+KBJPJWkR0ifqKT3irQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmaccess/-/libnpmaccess-3.0.1.tgz",
+      "integrity": "sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==",
       "dev": true,
       "requires": {
         "aproba": "^2.0.0",
         "get-stream": "^4.0.0",
         "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmconfig": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/libnpmconfig/-/libnpmconfig-1.2.1.tgz",
+      "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "find-up": "^3.0.0",
+        "ini": "^1.3.5"
+      }
+    },
+    "libnpmhook": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/libnpmhook/-/libnpmhook-5.0.2.tgz",
+      "integrity": "sha512-vLenmdFWhRfnnZiNFPNMog6CK7Ujofy2TWiM2CrpZUjBRIhHkJeDaAbJdYCT6W4lcHtyrJR8yXW8KFyq6UAp1g==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmorg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/libnpmorg/-/libnpmorg-1.0.0.tgz",
+      "integrity": "sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmpublish": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-1.1.0.tgz",
+      "integrity": "sha512-mQ3LT2EWlpJ6Q8mgHTNqarQVCgcY32l6xadPVPMcjWLtVLz7II4WlWkzlbYg1nHGAf+xyABDwS+3aNUiRLkyaA==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "normalize-package-data": "^2.4.0",
+        "npm-package-arg": "^6.1.0",
+        "npm-registry-fetch": "^3.8.0",
+        "semver": "^5.5.1",
+        "ssri": "^6.0.1"
+      },
+      "dependencies": {
+        "aproba": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmsearch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.0.tgz",
+      "integrity": "sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1",
+        "get-stream": "^4.0.0",
+        "npm-registry-fetch": "^3.8.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "libnpmteam": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmteam/-/libnpmteam-1.0.1.tgz",
+      "integrity": "sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==",
+      "dev": true,
+      "requires": {
+        "aproba": "^2.0.0",
+        "figgy-pudding": "^3.4.1",
+        "get-stream": "^4.0.0",
         "npm-registry-fetch": "^3.8.0"
       },
       "dependencies": {
@@ -6559,6 +6789,16 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lock-verify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lock-verify/-/lock-verify-2.0.2.tgz",
+      "integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
+      "dev": true,
+      "requires": {
+        "npm-package-arg": "^5.1.2 || 6",
+        "semver": "^5.4.1"
+      }
+    },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
@@ -6569,6 +6809,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.debounce": {
@@ -6738,9 +6984,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -7029,17 +7275,17 @@
       },
       "dependencies": {
         "yallist": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
     },
     "minizlib": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
-      "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
       "dev": true,
       "requires": {
         "minipass": "^2.2.1"
@@ -7419,6 +7665,12 @@
         }
       }
     },
+    "npm-logical-tree": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npm-logical-tree/-/npm-logical-tree-1.2.1.tgz",
+      "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
+      "dev": true
+    },
     "npm-package-arg": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.0.tgz",
@@ -7452,6 +7704,17 @@
         "semver": "^5.4.1"
       }
     },
+    "npm-profile": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-profile/-/npm-profile-4.0.1.tgz",
+      "integrity": "sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.2 || 2",
+        "figgy-pudding": "^3.4.1",
+        "npm-registry-fetch": "^3.8.0"
+      }
+    },
     "npm-registry-fetch": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.8.0.tgz",
@@ -7467,9 +7730,9 @@
       },
       "dependencies": {
         "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -8792,7 +9055,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -8954,9 +9217,9 @@
           }
         },
         "lru-cache": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -8964,9 +9227,9 @@
           }
         },
         "tar": {
-          "version": "4.4.7",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.7.tgz",
-          "integrity": "sha512-mR3MzsCdN0IEWjZRuF/J9gaWHnTwOvzjqPTcvi1xXgfKTDQRp39gRETPQEfPByAdEOGmZfx1HrRsn8estaEvtA==",
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -8979,9 +9242,9 @@
           },
           "dependencies": {
             "yallist": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-              "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+              "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
               "dev": true
             }
           }
@@ -9490,9 +9753,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
       "dev": true
     },
     "public-encrypt": {
@@ -10936,6 +11199,12 @@
         "is-regexp": "^1.0.0"
       }
     },
+    "stringify-package": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
+      "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
+      "dev": true
+    },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -10968,12 +11237,11 @@
       "dev": true
     },
     "strong-log-transformer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.0.0.tgz",
-      "integrity": "sha512-FQmNqAXJgOX8ygOcvPLlGWBNT41mvNJ9ALoYf0GTwVt9t30mGTqpmp/oJx5gLcu52DXK10kS7dVWhx8aPXDTlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
+      "integrity": "sha512-B3Hgul+z0L9a236FAUC9iZsL+nVHgoCJnqCbN588DjYxvGXaXaaFbfmQ/JhvKjZwsOukuR72XbHv71Qkug0HxA==",
       "dev": true,
       "requires": {
-        "byline": "^5.0.0",
         "duplexer": "^0.1.1",
         "minimist": "^1.2.0",
         "through": "^2.3.4"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "browserify": "^16.2.2",
     "chai": "^4.1.2",
-    "codecov": "^3.0.2",
+    "codecov": "^3.1.0",
     "concat-stream": "^1.6.2",
     "cross-env": "^5.1.4",
     "cz-conventional-changelog": "^2.1.0",
@@ -61,7 +61,7 @@
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^1.1.0",
     "karma-mocha": "^1.3.0",
-    "lerna": "^3.4.3",
+    "lerna": "^3.6.0",
     "lodash": "^4.17.10",
     "mocha": "^5.0.0",
     "nyc": "^13.1.0",


### PR DESCRIPTION
`har-validator` is in our lockfile at 5.1.2, which was unpublished (See ahmadnassri/node-har-validator#112), breaking our CI builds.

`har-validator` was a sub(-sub-sub)-dependency of lerna and codecov, so they were both upgraded to pick up the necessary changes.