### PR TITLE
feat: Add typescript definitions to all consumable modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,8 @@
-package.json
-lerna.json
-bundle.js
+**/package.json
+package-lock.json
 node_modules
 __snapshots__
 coverage
+.nyc_output
+**/dist
+CHANGELOG.md

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,23 +1,25 @@
 'use strict'
 
+const extend = require('xtend')
+
+const configStandard = require('eslint-config-standard')
+const configPrettierTs = require('eslint-config-prettier/@typescript-eslint')
+const pluginTs = require('@typescript-eslint/eslint-plugin')
+
 // HACK: overriding parserOptions doesn't seem to do anything because
 // eslint-config-standard specifies it; delete it as a workaround
-const standard = require('eslint-config-standard')
-delete standard.parserOptions
+delete configStandard.parserOptions
 
 module.exports = {
+  root: true,
   parserOptions: {ecmaVersion: 5},
   env: {es6: false},
-  extends: [
-    'standard',
-    'prettier',
-    'prettier/standard',
-    'plugin:prettier/recommended',
-  ],
+  extends: ['standard', 'plugin:prettier/recommended', 'prettier/standard'],
   overrides: [
     {
       files: [
         '.*.js',
+        '**/*.config.js',
         'packages/cli/**/*.js',
         'packages/fixtures/**/*.js',
         '**/integration/**/*.js',
@@ -28,8 +30,38 @@ module.exports = {
       env: {es6: true},
     },
     {
-      files: ['**/*test.js'],
+      files: ['**/*test.js', '**/__tests__/**', 'scripts/init-test-env.js'],
       env: {mocha: true},
+    },
+    {
+      files: ['**/*.ts', '**/*.tsx'],
+      parser: '@typescript-eslint/parser',
+      parserOptions: {
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+      env: {es6: true, browser: true},
+      plugins: ['@typescript-eslint'],
+      rules: extend(
+        pluginTs.configs.recommended.rules,
+        configPrettierTs.rules,
+        {
+          'no-dupe-class-members': 'off',
+          'no-redeclare': 'off',
+          'no-useless-constructor': 'off',
+          '@typescript-eslint/explicit-member-accessibility': 'off',
+          '@typescript-eslint/array-type': ['error', 'generic'],
+          '@typescript-eslint/no-unused-vars': [
+            'error',
+            {ignoreRestSiblings: true, argsIgnorePattern: '^_'},
+          ],
+          '@typescript-eslint/no-use-before-define': [
+            'error',
+            {functions: false, typedefs: false},
+          ],
+          '@typescript-eslint/prefer-interface': 'off',
+        }
+      ),
     },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1001,6 +1001,51 @@
     "@tracespace/xml-id": {
       "version": "file:packages/xml-id"
     },
+    "@types/node": {
+      "version": "10.12.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.24.tgz",
+      "integrity": "sha512-GWWbvt+z9G5otRBW8rssOFgRY87J9N/qbhqfjMZ+gUuL6zoL+Hm6gP/8qQBG4jjimqdaNLCehcVapZ/Fs2WjCQ=="
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.3.0.tgz",
+      "integrity": "sha512-s+vjO9+PvYS2A6FnQC/imyEDOkrEKIzSpPf2OEGnkKqa5+1d0cuXgCi/oROtuBht2/u/iK22nrYcO/Ei4R8F/g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "1.3.0",
+        "requireindex": "^1.2.0",
+        "tsutils": "^3.7.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.3.0.tgz",
+      "integrity": "sha512-Q5cz9nyEQyRrtItRElvQXdNs0Xja1xvOdphDQR7N6MqUdi4juWVNxHKypdHQCx9OcEBev6pWHOda8lwg/2W9/g==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "1.3.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.3.0.tgz",
+      "integrity": "sha512-h6UxHSmBUopFcxHg/eryrA+GwHMbh7PxotMbkq9p2f3nX60CKm5Zc0VN8krBD3IS5KqsK0iOz24VpEWrP+JZ2Q==",
+      "dev": true,
+      "requires": {
+        "lodash.unescape": "4.0.1",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -5627,6 +5672,7 @@
     "gerber-parser": {
       "version": "file:packages/gerber-parser",
       "requires": {
+        "@types/node": "^10.12.24",
         "inherits": "^2.0.3",
         "lodash.isfinite": "^3.3.2",
         "lodash.padend": "^4.6.1",
@@ -5637,6 +5683,7 @@
     "gerber-plotter": {
       "version": "file:packages/gerber-plotter",
       "requires": {
+        "@types/node": "^10.12.24",
         "inherits": "^2.0.3",
         "lodash.fill": "^3.4.0",
         "lodash.isfinite": "^3.3.2",
@@ -5648,6 +5695,7 @@
       "version": "file:packages/gerber-to-svg",
       "requires": {
         "@tracespace/xml-id": "file:packages/xml-id",
+        "@types/node": "^10.12.24",
         "escape-html": "^1.0.3",
         "gerber-parser": "file:packages/gerber-parser",
         "gerber-plotter": "file:packages/gerber-plotter",
@@ -7546,6 +7594,12 @@
       "requires": {
         "lodash._reinterpolate": "~3.0.0"
       }
+    },
+    "lodash.unescape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+      "dev": true
     },
     "log4js": {
       "version": "3.0.6",
@@ -10150,6 +10204,7 @@
       "version": "file:packages/pcb-stackup",
       "requires": {
         "@tracespace/xml-id": "file:packages/xml-id",
+        "@types/node": "^10.12.24",
         "gerber-to-svg": "file:packages/gerber-to-svg",
         "pcb-stackup-core": "file:packages/pcb-stackup-core",
         "run-parallel": "^1.1.9",
@@ -10162,6 +10217,7 @@
       "version": "file:packages/pcb-stackup-core",
       "requires": {
         "@tracespace/xml-id": "file:packages/xml-id",
+        "@types/node": "^10.12.24",
         "color-string": "^1.4.0",
         "gerber-to-svg": "file:packages/gerber-to-svg",
         "viewbox": "^1.0.0",
@@ -10924,6 +10980,12 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -12157,7 +12219,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -12198,6 +12260,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
+    },
+    "tsutils": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.8.0.tgz",
+      "integrity": "sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tty-browserify": {
       "version": "0.0.1",
@@ -12249,6 +12320,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3.tgz",
+      "integrity": "sha512-Y21Xqe54TBVp+VDSNbuDYdGw0BpoR/Q6wo/+35M8PAU0vipahnyduJWirxxdxjsAkS7hue53x2zp8gz7F05u0A==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "scripts": {
     "_test": "mocha --require scripts/init-test-env --timeout 5000 'packages/**/*test.js'",
     "test": "cross-env INTEGRATION=1 nyc npm run _test",
-    "posttest": "npm run example && npm run docs && npm run lint",
+    "posttest": "npm run example && npm run docs && npm run check && npm run lint",
     "test:watch": "npm run _test -- --watch --reporter=dot",
     "test:browser": "karma start",
     "coverage": "nyc report --reporter=lcov",
     "start": "lerna run start --parallel",
-    "lint": "eslint '.*.js' '**/*.js'",
-    "format": "prettier --ignore-path .eslintignore --write '.*.js' '**/*.js'",
+    "lint": "eslint '.*.js' '**/*.@(js|ts|tsx)'",
+    "format": "prettier --ignore-path .eslintignore --write '.*.@(js|yml)' '**/*.@(js|ts|tsx|json|md|yml)'",
+    "check": "tsc",
     "docs": "lerna run docs",
     "example": "lerna run example",
     "prebump": "npm run test",
@@ -40,6 +41,7 @@
     ]
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^1.3.0",
     "browserify": "^16.2.2",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
@@ -80,6 +82,7 @@
     "snap-shot-it": "^6.2.2",
     "testdouble": "^3.3.1",
     "to-readable-stream": "^1.0.0",
+    "typescript": "^3.3.3",
     "watchify": "^3.10.0",
     "xml-formatter": "^1.0.1"
   },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,9 +72,9 @@ tracespace --version
 
 #### `-o`, `--out`, `config.out`
 
-* Type: `string`
-* Default: `.`
-* Description: Output directory (or `-` for stdout)
+- Type: `string`
+- Default: `.`
+- Description: Output directory (or `-` for stdout)
 
 ```shell
 # Write SVGs into directory `./renders`
@@ -83,9 +83,9 @@ tracespace --out=renders
 
 #### `-B`, `--noBoard`, `config.noBoard`
 
-* Type: `boolean`
-* Default: `false`
-* Description: Skip rendering PCB top and bottom
+- Type: `boolean`
+- Default: `false`
+- Description: Skip rendering PCB top and bottom
 
 ```shell
 # Output only the individual layer renders
@@ -94,9 +94,9 @@ tracespace -B
 
 #### `-L`, `--noLayer`, `config.noLayer`
 
-* Type: `boolean`
-* Default: `false`
-* Description: Skip rendering individual Gerber and drill layers
+- Type: `boolean`
+- Default: `false`
+- Description: Skip rendering individual Gerber and drill layers
 
 ```shell
 # Output only the top and bottom PCB renders
@@ -105,9 +105,9 @@ tracespace -L
 
 #### `-f`, `--force`, `config.force`
 
-* Type: `boolean`
-* Default: `false`
-* Description: Attempt to render files even if they're unrecognized
+- Type: `boolean`
+- Default: `false`
+- Description: Attempt to render files even if they're unrecognized
 
 ```shell
 # Attempt render even if whats-that-gerber cannot identify
@@ -116,9 +116,9 @@ tracespace -B --force some-file.xyz
 
 #### `-g`, `--gerber`, `config.gerber`
 
-* Type: `object`
-* Default: `{}`
-* Description: Options for all gerber files (passed to gerber-to-svg)
+- Type: `object`
+- Default: `{}`
+- Description: Options for all gerber files (passed to gerber-to-svg)
 
 ```shell
 # Set the color attribute of all Gerber SVGs
@@ -127,9 +127,9 @@ tracespace -B -g.attributes.color=blue
 
 #### `-d`, `--drill`, `config.drill`
 
-* Type: `object`
-* Default: `{}`
-* Description: Options for all drill files (passed to gerber-to-svg)
+- Type: `object`
+- Default: `{}`
+- Description: Options for all drill files (passed to gerber-to-svg)
 
 ```shell
 # Set the color attribute of all drill SVGs
@@ -138,9 +138,9 @@ tracespace -B -d.attributes.color=red
 
 #### `-b`, `--board`, `config.board`
 
-* Type: `object`
-* Default: `{}`
-* Description: Options for PCB renders (passed to pcb-stackup)
+- Type: `object`
+- Default: `{}`
+- Description: Options for PCB renders (passed to pcb-stackup)
 
 ```shell
 # Set the soldermask color of the board renders
@@ -149,9 +149,9 @@ tracespace -b.color.sm="rgba(128,00,00,0.75)"
 
 #### `-l`, `--layer`, `config.layer`
 
-* Type: `object`
-* Default: `{}`
-* Description: Override the layers options of a given file
+- Type: `object`
+- Default: `{}`
+- Description: Override the layers options of a given file
 
 > If you're using this option a lot, you may want to consider using a config file
 
@@ -162,12 +162,13 @@ tracespace -l.arduino-uno.drd.type=drill -l.arduino-uno.drd.options.filetype=dri
 
 #### `-q`, `--quiet`, `config.quiet`
 
-* Type: `boolean`
-* Default: `false`
-* Description: Suppress informational output (info logs to stderr)
+- Type: `boolean`
+- Default: `false`
+- Description: Suppress informational output (info logs to stderr)
 
 ```shell
 # Do not print info to stderr
 tracespace --quiet
 ```
+
 <!-- endinsert:docs:options -->

--- a/packages/cli/scripts/docs.js
+++ b/packages/cli/scripts/docs.js
@@ -39,7 +39,7 @@ readFile(doc, 'utf8')
 function insertOptionsIntoDocument(contents) {
   return contents.replace(
     matcher('options'),
-    (match, startTag, endTag) => `${startTag}${generateOptions()}${endTag}`
+    (_match, startTag, endTag) => `${startTag}${generateOptions()}\n${endTag}`
   )
 }
 
@@ -61,9 +61,9 @@ function generateOptions() {
       return `
 #### \`-${short}\`, \`--${long}\`, \`config.${long}\`
 
-* Type: \`${type}\`
-* Default: \`${defaultValue || getDefaultFromType(type)}\`
-* Description: ${describe}
+- Type: \`${type}\`
+- Default: \`${defaultValue || getDefaultFromType(type)}\`
+- Description: ${describe}
 ${example.aside ? `\n> ${example.aside}\n` : ''}
 \`\`\`shell
 # ${example.desc}

--- a/packages/gerber-parser/index.d.ts
+++ b/packages/gerber-parser/index.d.ts
@@ -1,0 +1,34 @@
+// Type definitions for gerber-parser 4.0
+// Project: https://github.com/tracespace/tracespace
+// Definitions by: Mike Cousins <https://mike.cousins.io>
+
+/// <reference types="node" />
+
+declare function gerberParser(
+  options: gerberParser.Options
+): gerberParser.Parser
+
+declare namespace gerberParser {
+  interface Parser extends NodeJS.ReadWriteStream {
+    line: number
+    format: {
+      places: CoordinateFormat
+      zero: ZeroSuppression
+      filetype: FileType
+    }
+  }
+
+  interface Options {
+    places?: CoordinateFormat | null
+    zero?: ZeroSuppression | null
+    filetype?: FileType | null
+  }
+
+  type CoordinateFormat = [number, number]
+
+  type ZeroSuppression = 'L' | 'T'
+
+  type FileType = 'gerber' | 'drill'
+}
+
+export = gerberParser

--- a/packages/gerber-parser/package.json
+++ b/packages/gerber-parser/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0-next.17",
   "description": "Streaming Gerber/drill file parser",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tracespace/tracespace.git"
@@ -25,6 +26,7 @@
   },
   "homepage": "https://github.com/tracespace/tracespace#readme",
   "dependencies": {
+    "@types/node": "^10.12.24",
     "inherits": "^2.0.3",
     "lodash.isfinite": "^3.3.2",
     "lodash.padend": "^4.6.1",

--- a/packages/gerber-plotter/index.d.ts
+++ b/packages/gerber-plotter/index.d.ts
@@ -1,0 +1,35 @@
+// Type definitions for gerber-plotter 4.0
+// Project: https://github.com/tracespace/tracespace
+// Definitions by: Mike Cousins <https://mike.cousins.io>
+
+/// <reference types="node" />
+
+declare function gerberPlotter(
+  options: gerberPlotter.Options
+): gerberPlotter.Plotter
+
+declare namespace gerberPlotter {
+  interface Plotter extends NodeJS.ReadWriteStream {
+    format: {
+      units: Units
+      backupUnits: Units
+      nota: Notation
+      backupNota: Notation
+    }
+  }
+
+  interface Options {
+    units?: Units | null
+    backupUnits?: Units | null
+    nota?: Notation | null
+    backupNota?: Notation | null
+    optimizePaths?: boolean | null
+    plotAsOutline?: boolean | number | null
+  }
+
+  type Units = 'mm' | 'in'
+
+  type Notation = 'A' | 'I'
+}
+
+export = gerberPlotter

--- a/packages/gerber-plotter/package.json
+++ b/packages/gerber-plotter/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0-next.15",
   "description": "Streaming Gerber / NC drill layer image plotter",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tracespace/tracespace.git"
@@ -28,6 +29,7 @@
     "gerber-parser": "^4.0.0"
   },
   "dependencies": {
+    "@types/node": "^10.12.24",
     "inherits": "^2.0.3",
     "lodash.fill": "^3.4.0",
     "lodash.isfinite": "^3.3.2",

--- a/packages/gerber-to-svg/index.d.ts
+++ b/packages/gerber-to-svg/index.d.ts
@@ -1,0 +1,73 @@
+// Type definitions for gerber-to-svg 4.0
+// Project: https://github.com/tracespace/tracespace
+// Definitions by: Mike Cousins <https://mike.cousins.io>
+
+/// <reference types="node" />
+
+import {Parser, Options as ParserOptions} from 'gerber-parser'
+import {Plotter, Options as PlotterOptions} from 'gerber-plotter'
+
+declare function gerberToSvg<NodeType = string>(
+  gerber: gerberToSvg.GerberSource,
+  options?:
+    | string
+    | gerberToSvg.Options<NodeType>
+    | gerberToSvg.Callback<NodeType>,
+  done?: gerberToSvg.Callback<NodeType>
+): gerberToSvg.Converter<NodeType>
+
+declare namespace gerberToSvg {
+  function clone<NodeType = string>(
+    converter: Converter<NodeType>
+  ): ConverterResult<NodeType>
+
+  function render<NodeType = string>(
+    converter: ConverterResult<NodeType>,
+    attributes: object | string,
+    createElement?: CreateElement<NodeType>,
+    objectMode?: ObjectMode<NodeType>
+  ): NodeType
+
+  type GerberSource = string | Buffer | NodeJS.ReadableStream
+
+  type ObjectMode<NodeType = string> = NodeType extends string
+    ? NodeType extends Buffer
+      ? false
+      : true
+    : true
+
+  interface CreateElement<NodeType = string> {
+    (tag: string, attributes: object, children: Array<NodeType>): NodeType
+  }
+
+  interface Converter<NodeType = string>
+    extends NodeJS.ReadableStream,
+      ConverterResult<NodeType> {
+    parser: Parser
+    plotter: Plotter
+  }
+
+  interface ConverterResult<NodeType = string> {
+    id: string
+    attributes: object
+    defs: Array<NodeType>
+    layer: Array<NodeType>
+    viewBox: Array<number>
+    width: number
+    height: number
+    units: 'in' | 'mm'
+  }
+
+  interface Options<NodeType = string> extends ParserOptions, PlotterOptions {
+    id?: string
+    attributes?: object
+    createElement?: CreateElement<NodeType>
+    objectMode?: ObjectMode<NodeType>
+  }
+
+  interface Callback<NodeType = string> {
+    (error: Error, result: NodeType): unknown
+  }
+}
+
+export = gerberToSvg

--- a/packages/gerber-to-svg/package.json
+++ b/packages/gerber-to-svg/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0-next.18",
   "description": "Render individual Gerber / NC drill files as SVGs",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "example": "node example",
     "start": "node integration/server"
@@ -35,6 +36,7 @@
   "homepage": "https://github.com/tracespace/tracespace#readme",
   "dependencies": {
     "@tracespace/xml-id": "file:../xml-id",
+    "@types/node": "^10.12.24",
     "escape-html": "^1.0.3",
     "gerber-parser": "file:../gerber-parser",
     "gerber-plotter": "file:../gerber-plotter",

--- a/packages/pcb-stackup-core/index.d.ts
+++ b/packages/pcb-stackup-core/index.d.ts
@@ -1,0 +1,58 @@
+// Type definitions for pcb-stackup-core 4.0
+// Project: https://github.com/tracespace/tracespace
+// Definitions by: Mike Cousins <https://mike.cousins.io>
+
+/// <reference types="node" />
+
+import {Converter, ConverterResult, CreateElement} from 'gerber-to-svg'
+import {GerberSide, GerberType} from 'whats-that-gerber'
+
+declare function pcbStackupCore<NodeType = string>(
+  layers: Array<pcbStackupCore.Layer>,
+  options: string | pcbStackupCore.Options<NodeType>
+): pcbStackupCore.Stackup<NodeType>
+
+declare namespace pcbStackupCore {
+  interface Layer {
+    side: GerberSide
+    type: GerberType
+    converter: Converter
+    externalId?: string | null
+  }
+
+  interface Options<NodeType = string> {
+    id: string
+    color?: ColorOptions
+    attributes?: object
+    useOutline?: boolean
+    createElement?: CreateElement<NodeType>
+  }
+
+  interface Stackup<NodeType = string> {
+    id: string
+    color: Color
+    attributes: object
+    useOutline: boolean
+    createElement: CreateElement<NodeType>
+    top: StackupSide<NodeType>
+    bottom: StackupSide<NodeType>
+  }
+
+  interface StackupSide<NodeType = string> extends ConverterResult<NodeType> {
+    svg: NodeType
+  }
+
+  interface Color {
+    fr4: string
+    cu: string
+    cf: string
+    sm: string
+    ss: string
+    sp: string
+    out: string
+  }
+
+  type ColorOptions = {[P in keyof Color]?: Color[P] | null}
+}
+
+export = pcbStackupCore

--- a/packages/pcb-stackup-core/package.json
+++ b/packages/pcb-stackup-core/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0-next.15",
   "description": "Layer stacking core logic for pcb-stackup",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "example": "node example",
     "start": "node integration/server"
@@ -31,6 +32,7 @@
   "homepage": "https://github.com/tracespace/tracespace",
   "dependencies": {
     "@tracespace/xml-id": "file:../xml-id",
+    "@types/node": "^10.12.24",
     "color-string": "^1.4.0",
     "gerber-to-svg": "file:../gerber-to-svg",
     "viewbox": "^1.0.0",

--- a/packages/pcb-stackup/index.d.ts
+++ b/packages/pcb-stackup/index.d.ts
@@ -1,0 +1,77 @@
+// Type definitions for pcb-stackup 4.0
+// Project: https://github.com/tracespace/tracespace
+// Definitions by: Mike Cousins <https://mike.cousins.io>
+
+/// <reference types="node" />
+
+import {
+  GerberSource,
+  ConverterResult,
+  CreateElement,
+  Options as GerberOptions,
+} from 'gerber-to-svg'
+
+import {
+  Stackup as CoreStackup,
+  Layer as CoreLayer,
+  Options as CoreOptions,
+} from 'pcb-stackup-core'
+
+import {GerberSide, GerberType} from 'whats-that-gerber'
+
+declare function pcbStackup<NodeType = string, Layer = pcbStackup.InputLayer>(
+  layers: Array<Layer>,
+  done: pcbStackup.Callback<NodeType, Layer>
+): void
+
+declare function pcbStackup<NodeType = string, Layer = pcbStackup.InputLayer>(
+  layers: Array<Layer>,
+  options: pcbStackup.Options | null,
+  done: pcbStackup.Callback<NodeType, Layer>
+): void
+
+declare function pcbStackup<NodeType = string, Layer = pcbStackup.InputLayer>(
+  layers: Array<Layer>,
+  options?: pcbStackup.Options | null
+): Promise<pcbStackup.Stackup<NodeType, Layer>>
+
+declare namespace pcbStackup {
+  interface InputLayer {
+    filename?: string
+    gerber?: GerberSource
+    options?: GerberOptions | string
+    side?: GerberSide
+    type?: GerberType
+    converter?: ConverterResult
+    externalId?: string | null
+  }
+
+  type OutputLayer<Layer = InputLayer> = Layer &
+    CoreLayer & {
+      options: {
+        id: string
+        plotAsOutline: boolean | number
+        createElement: CreateElement
+      }
+    }
+
+  interface Stackup<NodeType = string, Layer = InputLayer>
+    extends CoreStackup<NodeType> {
+    layers: Array<OutputLayer<Layer>>
+    outlineGapFill: number | null
+  }
+
+  type Options<NodeType = string> = Pick<
+    CoreOptions,
+    Exclude<keyof CoreOptions, 'id'>
+  > & {
+    id?: string
+    outlineGapFill?: number
+  }
+
+  interface Callback<NodeType = string, Input = InputLayer> {
+    (error: Error, stackup: Stackup<NodeType, Input>): unknown
+  }
+}
+
+export = pcbStackup

--- a/packages/pcb-stackup/package.json
+++ b/packages/pcb-stackup/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0-next.18",
   "description": "Render PCBs as beautiful, precise SVGs from Gerber / NC drill files",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "example": "node example",
     "start": "node integration/server"
@@ -33,6 +34,7 @@
   "homepage": "https://github.com/tracespace/tracespace",
   "dependencies": {
     "@tracespace/xml-id": "file:../xml-id",
+    "@types/node": "^10.12.24",
     "gerber-to-svg": "file:../gerber-to-svg",
     "pcb-stackup-core": "file:../pcb-stackup-core",
     "run-parallel": "^1.1.9",

--- a/packages/whats-that-gerber/index.d.ts
+++ b/packages/whats-that-gerber/index.d.ts
@@ -1,0 +1,52 @@
+// Type definitions for whats-that-gerber 4.0
+// Project: https://github.com/tracespace/tracespace
+// Definitions by: Mike Cousins <https://mike.cousins.io>
+
+declare function whatsThatGerber<T extends string>(
+  filenames: ReadonlyArray<T>
+): Record<T, whatsThatGerber.GerberProps>
+
+declare namespace whatsThatGerber {
+  // TODO(mc, 2018-11-21): dedupe this definition and source
+  const TYPE_COPPER = 'copper'
+  const TYPE_SOLDERMASK = 'soldermask'
+  const TYPE_SILKSCREEN = 'silkscreen'
+  const TYPE_SOLDERPASTE = 'solderpaste'
+  const TYPE_DRILL = 'drill'
+  const TYPE_OUTLINE = 'outline'
+  const TYPE_DRAWING = 'drawing'
+
+  // board sides
+  const SIDE_TOP = 'top'
+  const SIDE_BOTTOM = 'bottom'
+  const SIDE_INNER = 'inner'
+  const SIDE_ALL = 'all'
+
+  function validate(target: object): GerberProps & {valid: boolean}
+
+  function getAllLayers(): Array<GerberProps>
+
+  type GerberType =
+    | typeof TYPE_COPPER
+    | typeof TYPE_SOLDERMASK
+    | typeof TYPE_SILKSCREEN
+    | typeof TYPE_SOLDERPASTE
+    | typeof TYPE_DRILL
+    | typeof TYPE_OUTLINE
+    | typeof TYPE_DRAWING
+    | null
+
+  type GerberSide =
+    | typeof SIDE_TOP
+    | typeof SIDE_BOTTOM
+    | typeof SIDE_INNER
+    | typeof SIDE_ALL
+    | null
+
+  interface GerberProps {
+    type: GerberType
+    side: GerberSide
+  }
+}
+
+export = whatsThatGerber

--- a/packages/whats-that-gerber/package.json
+++ b/packages/whats-that-gerber/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0-next.15",
   "description": "Identify Gerber and drill files by filenamee",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tracespace/tracespace.git"

--- a/packages/xml-id/index.d.ts
+++ b/packages/xml-id/index.d.ts
@@ -1,0 +1,11 @@
+// Type definitions for @tracespace/xml-id 4.0
+// Project: https://github.com/tracespace/tracespace
+// Definitions by: Mike Cousins <https://mike.cousins.io>
+
+declare namespace xmlId {
+  function random(length?: number): string
+  function sanitize(input: string): string
+  function ensure(maybeId: unknown, length?: number): string
+}
+
+export = xmlId

--- a/packages/xml-id/package.json
+++ b/packages/xml-id/package.json
@@ -6,6 +6,7 @@
   "version": "4.0.0-next.15",
   "description": "XML ID utilities for tracespace projects",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tracespace/tracespace.git"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "jsx": "preserve",
+    "declaration": true,
+    "outDir": "lib",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
~Blocked by #102; this PR to be rebased over `next` once it's merged.~

This PR adds Typescript definitions to all consumable modules. The upcoming viewer rewrite is in Typescript (see mcous/tracespace#1), so this seemed like a good thing to do.

It also sets up eslint and prettier to handle Typescript. The unrelated `.md` changes are a side-effect of being better about running prettier on everything. Was easier to include them here than do a separate PR, but sorry for the noise regardless.