### PR TITLE
fix(gerber-to-svg): Allow options parameter to be skipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tracespace",
   "private": true,
   "scripts": {
-    "_test": "mocha --require scripts/init-test-env --timeout 15000 '@(packages|apps)/**/*test.@(js|ts|tsx)'",
+    "_test": "mocha --require scripts/init-test-env '@(packages|apps)/**/*test.@(js|ts|tsx)'",
     "test": "cross-env INTEGRATION=1 nyc npm run _test",
     "posttest": "npm run example && npm run docs && npm run check && npm run lint",
     "test:watch": "npm run _test -- --watch --reporter dot --watch-extensions js,ts,tsx",

--- a/packages/gerber-plotter/integration/gerber-plotter-snapshot.test.js
+++ b/packages/gerber-plotter/integration/gerber-plotter-snapshot.test.js
@@ -9,6 +9,8 @@ const getResults = require('./get-results')
 const SUITES = [...getBoards.sync().filter(b => !b.skipSnapshot)]
 
 describe(`gerber-plotter :: integration`, function() {
+  this.timeout(15000)
+
   SUITES.forEach(suite =>
     describe(suite.name, function() {
       const specs = suite.specs || suite.layers

--- a/packages/gerber-to-svg/index.js
+++ b/packages/gerber-to-svg/index.js
@@ -41,9 +41,9 @@ var parseOptions = function(options) {
 }
 
 module.exports = function gerberConverterFactory(gerber, inputOpts, done) {
-  if (typeof options === 'function') {
+  if (typeof inputOpts === 'function') {
     done = inputOpts
-    inputOpts = {}
+    inputOpts = null
   }
 
   var opts = parseOptions(inputOpts)

--- a/packages/gerber-to-svg/integration/gerber-to-svg-snapshot.test.js
+++ b/packages/gerber-to-svg/integration/gerber-to-svg-snapshot.test.js
@@ -13,6 +13,8 @@ const SUITES = [
 ]
 
 describe(`gerber-to-svg :: integration`, function() {
+  this.timeout(15000)
+
   SUITES.forEach(suite =>
     describe(suite.name, function() {
       const specs = suite.specs || suite.layers

--- a/packages/gerber-to-svg/test/gerber-to-svg_test.js
+++ b/packages/gerber-to-svg/test/gerber-to-svg_test.js
@@ -96,6 +96,18 @@ describe('gerber to svg', function() {
     fakeConverter.emit('end')
   })
 
+  it('should allow options param to be skipped', function(done) {
+    gerberToSvg('foobar*\n', function(error, result) {
+      expect(error == null).to.equal(true)
+      expect(result).to.equal('<svg />')
+      done()
+    })
+
+    fakeConverter.read.onCall(0).returns('<svg />')
+    fakeConverter.emit('readable')
+    fakeConverter.emit('end')
+  })
+
   it('should pipe a stream input into the parser and listen for errors', function() {
     var input = {pipe: sinon.spy(), setEncoding: sinon.spy()}
 

--- a/packages/pcb-stackup-core/integration/pcb-stackup-core-snapshot.test.js
+++ b/packages/pcb-stackup-core/integration/pcb-stackup-core-snapshot.test.js
@@ -11,6 +11,8 @@ const SIDES = ['top', 'bottom']
 const BOARDS = getBoards.sync().filter(b => !b.skipSnapshot)
 
 describe(`pcb-stackup-core :: integration`, function() {
+  this.timeout(15000)
+
   BOARDS.forEach((board, index) =>
     describe(board.name, function() {
       let boardResults

--- a/packages/pcb-stackup/integration/pcb-stackup-snapshot.test.js
+++ b/packages/pcb-stackup/integration/pcb-stackup-snapshot.test.js
@@ -11,6 +11,8 @@ const SIDES = ['top', 'bottom']
 const BOARDS = getBoards.sync().filter(b => !b.skipSnapshot)
 
 describe(`pcb-stackup :: integration snapshots`, function() {
+  this.timeout(15000)
+
   BOARDS.forEach((board, index) =>
     describe(board.name, function() {
       let boardResults


### PR DESCRIPTION
While working on #180, I found a typo in gerber-to-svg that was preventing the `done` callback from being properly registered if the `options` object was skipped. This PR fixes that bug