### PR TITLE
fix(gerber-plotter): Emit correct 'repeat' object on steprepeat disable

### DIFF
--- a/packages/gerber-plotter/lib/plotter.js
+++ b/packages/gerber-plotter/lib/plotter.js
@@ -271,11 +271,14 @@ Plotter.prototype._transform = function(chunk, encoding, done) {
     } else {
       // calculate new offsets
       var offsets = []
-      for (var x = 0; x < levelValue.x; x++) {
-        for (var y = 0; y < levelValue.y; y++) {
-          offsets.push([x * levelValue.i, y * levelValue.j])
+      if (levelValue.x > 1 || levelValue.y > 1) {
+        for (var x = 0; x < levelValue.x; x++) {
+          for (var y = 0; y < levelValue.y; y++) {
+            offsets.push([x * levelValue.i, y * levelValue.j])
+          }
         }
       }
+
       this._stepRep = offsets
 
       this.push({

--- a/packages/gerber-plotter/test/gerber-plotter_test.js
+++ b/packages/gerber-plotter/test/gerber-plotter_test.js
@@ -2072,6 +2072,20 @@ describe('gerber plotter', function() {
       p.write({type: 'op', op: 'flash', coord: {x: -3, y: 4}})
       expect(p._box).to.eql([-4, 0, 1.5, 5])
     })
+
+    it('should emit an empty step repeat if SR is disabled', function(done) {
+      p.once('readable', function() {
+        var result = p.read()
+        expect(result.offsets).to.eql([])
+        done()
+      })
+
+      p.write({
+        type: 'level',
+        level: 'stepRep',
+        value: {x: 1, y: 1, i: 0, j: 0},
+      })
+    })
   })
 
   describe('ending the stream', function() {


### PR DESCRIPTION
According to the [gerber-plotter docs](https://github.com/tracespace/tracespace/blob/master/packages/gerber-plotter/API.md#block-repeat-objects):

> A repeat object with a zero-length offsets array means repeating has been turned off.

Instead of this, the plotter was emitting a repeat object with an offsets array of `[[0,0]]`. This PR changes the plotter behavior to match its documentation (and the expectations of gerber-to-svg).

Closes #81