### PR TITLE
chore(.gitignore): Add MacOS system files .DS_Store to be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ bundle.*
 **/dist
 */**/LICENSE
 **/*.tgz
+
+# system files
+.DS_Store
+*/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ bundle.*
 
 # system files
 .DS_Store
-*/.DS_Store


### PR DESCRIPTION
.DS_Store is a file that stores custom attributes of its containing folder, such as the position of
icons or the choice of a background image. The files sometimes get automatically created and are
meaningless to the project and thus must be excluded.