### PR TITLE
ci(travis): Fix example file deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,23 @@ _deploy_base: &_deploy_base
 # jobs for node_js versions above automatically added to matrix "test" stage
 jobs:
   include:
-    - # test that app builds all work
+    - # lint and typecheck
       stage: test
-      name: App builds
-      script: npm run build
+      name: Lint and typecheck
+      script:
+        - npm run lint
+        - npm run check
+
+    - # test that asset builds all work
+      stage: test
+      name: Build assets
+      script: npm run build:all
 
     - # build and publish
       if: tag =~ ^v OR (branch = master AND type != pull_request)
       stage: deploy
       name: Deploy to npm and s3
-      script: npm run build
+      script: npm run build:all
       before_deploy:
         # set npm deploy parameters
         - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN

--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ All development scripts below **should be run from the root of the repository**.
 Automated tests consist of unit tests along with integration [snapshot tests][snapshot-testing] of SVG and data outputs.
 
 ```shell
-# run unit and integration tests tests with coverage and linting
+# run unit and integration tests tests with coverage
 npm test
 
 # set SNAPSHOT_UPDATE=1 to update integration test snapshots
 SNAPSHOT_UPDATE=1 npm test
 
-# run unit tests in watch mode (no coverage, no linting)
+# run unit tests in watch mode (no coverage)
 npm run test:watch
 
 # set INTEGRATION=1 to also include integration tests
@@ -262,10 +262,36 @@ npm run start
 npm run start -- --scope @tracespace/view
 ```
 
-`@tracespace/view` can also build and serve its production assets as a sanity check before deploying:
+### production assets
+
+There are two production asset types that you can build:
+
+- Full web-app bundles
+  - `@tracespace/view`
+- Standalone library bundles
+  - `gerber-parser`
+  - `gerber-plotter`
+  - `gerber-to-svg`
+  - `pcb-stackup-core`
+  - `pcb-stackup`
+  - `whats-that-gerber`
+
+To build them:
 
 ```shell
+# build production bundles
+npm run build
+
+# build:all
+# builds all production bundles, example files, and documentation
+npm run build:all
+
+# build all bundles and serve them for testing/validation
 npm run serve
+
+# as with the dev server, these commands may be scoped by name
+npm run build -- --scope gerber-parser
+npm run serve -- --scope @tracespace/view
 ```
 
 ### linting and formatting
@@ -276,6 +302,9 @@ npm run format
 
 # lint the code for potential errors
 npm run lint
+
+# typecheck any typescript code
+npm run check
 ```
 
 ### publishing

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "scripts": {
     "_test": "mocha --require scripts/init-test-env '@(packages|apps)/**/*test.@(js|ts|tsx)'",
     "test": "cross-env INTEGRATION=1 nyc npm run _test",
-    "posttest": "npm run example && npm run docs && npm run check && npm run lint",
     "test:watch": "npm run _test -- --watch --reporter dot --watch-extensions js,ts,tsx",
     "coverage": "nyc report --reporter=lcov",
     "start": "lerna run start --parallel",
     "build": "lerna run build --parallel",
     "serve": "lerna run serve --parallel",
+    "build:all": "npm run build && npm run example && npm run docs",
     "lint": "eslint '.*.js' '**/*.@(js|ts|tsx)'",
     "format": "prettier --ignore-path .eslintignore --write '.*.@(js|yml)' '**/*.@(js|ts|tsx|json|md|yml)'",
     "check": "tsc",


### PR DESCRIPTION
#180 broke the example file upload to `npm` because I forgot to include `npm run example` in the combined build and publish job. This PR fixes that oversight and improves the build docs slightly