### PR TITLE
fix(whats-that-gerber): Add support for PCB:NG Eagle, .gbx, and .art

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -3,6 +3,6 @@
 
 module.exports = {
   require: ['scripts/init-test-env'],
-  'watch-extensions': ['js', 'ts', 'tsx'],
+  'watch-extensions': ['js', 'ts', 'tsx', 'json'],
   spec: ['apps/**/__tests__/*.@(js|ts|tsx)', 'packages/**/*test.js'],
 }

--- a/apps/view/src/render/models.ts
+++ b/apps/view/src/render/models.ts
@@ -208,13 +208,15 @@ function fileStreamToInputLayer(gerber: FileStream): InputLayerFromFile {
 }
 
 function stackupToBoardName(stackup: Stackup): string {
-  return (
+  const boardName =
     commonPrefix(
       stackup.layers
         .filter(ly => ly.converter.layer.length > 0)
         .map(ly => baseName(ly.filename || '', true))
     ) || DEFAULT_BOARD_NAME
-  )
+
+  // strip trailing dot if present
+  return boardName.endsWith('.') ? boardName.slice(0, -1) : boardName
 }
 
 function stackupToBoardOptions(stackup: Stackup): Board['options'] {

--- a/packages/fixtures/gerber-filenames.json
+++ b/packages/fixtures/gerber-filenames.json
@@ -174,6 +174,38 @@
     ]
   },
   {
+    "cad": "eagle-pcbng",
+    "files": [
+      {"name": "board.drill.txt", "side": "all", "type": "drill"},
+      {"name": "pnp_bom.txt", "side": null, "type": null},
+      {"name": "board.outline.gbr", "side": "all", "type": "outline"},
+      {"name": "board.bottom_copper.gbr", "side": "bottom", "type": "copper"},
+      {"name": "board.bottom_mask.gbr", "side": "bottom", "type": "soldermask"},
+      {
+        "name": "board.bottom_paste.gbr",
+        "side": "bottom",
+        "type": "solderpaste"
+      },
+      {"name": "board.bottom_silk.gbr", "side": "bottom", "type": "silkscreen"},
+      {"name": "board.top_copper.gbr", "side": "top", "type": "copper"},
+      {"name": "board.top_mask.gbr", "side": "top", "type": "soldermask"},
+      {"name": "board.top_paste.gbr", "side": "top", "type": "solderpaste"},
+      {"name": "board.top_silk.gbr", "side": "top", "type": "silkscreen"},
+      {"name": "board_bom.csv", "side": null, "type": null},
+      {"name": "board.bottom_copper.gpi", "side": null, "type": null},
+      {"name": "board.bottom_mask.gpi", "side": null, "type": null},
+      {"name": "board.bottom_paste.gpi", "side": null, "type": null},
+      {"name": "board.bottom_silk.gpi", "side": null, "type": null},
+      {"name": "board_centroid.csv", "side": null, "type": null},
+      {"name": "board.drill.dri", "side": null, "type": null},
+      {"name": "board.outline.gpi", "side": null, "type": null},
+      {"name": "board.top_copper.gpi", "side": null, "type": null},
+      {"name": "board.top_mask.gpi", "side": null, "type": null},
+      {"name": "board.top_paste.gpi", "side": null, "type": null},
+      {"name": "board.top_silk.gpi", "side": null, "type": null}
+    ]
+  },
+  {
     "cad": "eagle",
     "files": [
       {"name": "profile.gbr", "side": "all", "type": "outline"},

--- a/packages/whats-that-gerber/index.js
+++ b/packages/whats-that-gerber/index.js
@@ -22,6 +22,7 @@ function whatsThatGerber(filenames) {
 
   return filenames.reduce(function(result, filename) {
     var match = _selectMatch(matches, filename, commonCad)
+
     result[filename] = match
       ? {type: match.type, side: match.side}
       : {type: null, side: null}
@@ -31,9 +32,13 @@ function whatsThatGerber(filenames) {
 }
 
 function getAllLayers() {
-  return layerTypes.map(function(layer) {
-    return {type: layer.type, side: layer.side}
-  })
+  return layerTypes
+    .map(function(layer) {
+      return {type: layer.type, side: layer.side}
+    })
+    .filter(function(layer) {
+      return layer.type !== null
+    })
 }
 
 function validate(target) {

--- a/packages/whats-that-gerber/lib/constants.js
+++ b/packages/whats-that-gerber/lib/constants.js
@@ -20,9 +20,11 @@ module.exports = {
   // internal use only, for now
   _CAD_KICAD: 'kicad',
   _CAD_ALTIUM: 'altium',
+  _CAD_ALLEGRO: 'allegro',
+  _CAD_EAGLE: 'eagle',
   _CAD_EAGLE_LEGACY: 'eagle-legacy',
   _CAD_EAGLE_OSHPARK: 'eagle-oshpark',
-  _CAD_EAGLE: 'eagle',
+  _CAD_EAGLE_PCBNG: 'eagle-pcbng',
   _CAD_GEDA_PCB: 'geda-pcb',
   _CAD_ORCAD: 'orcad',
   _CAD_DIPTRACE: 'diptrace',

--- a/packages/whats-that-gerber/lib/layer-types.js
+++ b/packages/whats-that-gerber/lib/layer-types.js
@@ -3,6 +3,37 @@
 var c = require('./constants')
 
 module.exports = [
+  // high-priority blacklist
+  {
+    type: null,
+    side: null,
+    matchers: [
+      // eagle gerber generation metadata
+      {
+        ext: 'gpi',
+        cad: [
+          c._CAD_EAGLE,
+          c._CAD_EAGLE_LEGACY,
+          c._CAD_EAGLE_OSHPARK,
+          c._CAD_EAGLE_PCBNG,
+        ],
+      },
+      // eagle drill generation metadata
+      {
+        ext: 'dri',
+        cad: [
+          c._CAD_EAGLE,
+          c._CAD_EAGLE_LEGACY,
+          c._CAD_EAGLE_OSHPARK,
+          c._CAD_EAGLE_PCBNG,
+        ],
+      },
+      // general data/BOM files
+      {ext: 'csv', cad: null},
+      // pick-n-place BOMs
+      {match: /pnp_bom/, cad: c._CAD_EAGLE_PCBNG},
+    ],
+  },
   {
     type: c.TYPE_COPPER,
     side: c.SIDE_TOP,
@@ -14,6 +45,7 @@ module.exports = [
       {match: /top\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]cu/, cad: c._CAD_KICAD},
       {match: /copper_top/, cad: c._CAD_EAGLE},
+      {match: /top_copper/, cad: c._CAD_EAGLE_PCBNG},
       {match: /top copper/, cad: null},
     ],
   },
@@ -29,6 +61,7 @@ module.exports = [
       {match: /topmask\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]mask/, cad: c._CAD_KICAD},
       {match: /soldermask_top/, cad: c._CAD_EAGLE},
+      {match: /top_mask/, cad: c._CAD_EAGLE_PCBNG},
       {match: /top solder resist/, cad: null},
     ],
   },
@@ -44,6 +77,7 @@ module.exports = [
       {match: /topsilk\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]silks/, cad: c._CAD_KICAD},
       {match: /silkscreen_top/, cad: c._CAD_EAGLE},
+      {match: /top_silk/, cad: c._CAD_EAGLE_PCBNG},
       {match: /top silk screen/, cad: null},
     ],
   },
@@ -59,6 +93,7 @@ module.exports = [
       {match: /toppaste\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /f[._]paste/, cad: c._CAD_KICAD},
       {match: /solderpaste_top/, cad: c._CAD_EAGLE},
+      {match: /top_paste/, cad: c._CAD_EAGLE_PCBNG},
     ],
   },
   {
@@ -72,6 +107,7 @@ module.exports = [
       {match: /bottom\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]cu/, cad: c._CAD_KICAD},
       {match: /copper_bottom/, cad: c._CAD_EAGLE},
+      {match: /bottom_copper/, cad: c._CAD_EAGLE_PCBNG},
       {match: /bottom copper/, cad: null},
     ],
   },
@@ -87,6 +123,7 @@ module.exports = [
       {match: /bottommask\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]mask/, cad: c._CAD_KICAD},
       {match: /soldermask_bottom/, cad: c._CAD_EAGLE},
+      {match: /bottom_mask/, cad: c._CAD_EAGLE_PCBNG},
       {match: /bottom solder resist/, cad: null},
     ],
   },
@@ -102,6 +139,7 @@ module.exports = [
       {match: /bottomsilk\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]silks/, cad: c._CAD_KICAD},
       {match: /silkscreen_bottom/, cad: c._CAD_EAGLE},
+      {match: /bottom_silk/, cad: c._CAD_EAGLE_PCBNG},
       {match: /bottom silk screen/, cad: null},
     ],
   },
@@ -117,6 +155,7 @@ module.exports = [
       {match: /bottompaste\.\w+$/, cad: [c._CAD_GEDA_PCB, c._CAD_DIPTRACE]},
       {match: /b[._]paste/, cad: c._CAD_KICAD},
       {match: /solderpaste_bottom/, cad: c._CAD_EAGLE},
+      {match: /bottom_paste/, cad: c._CAD_EAGLE_PCBNG},
     ],
   },
   {
@@ -142,7 +181,7 @@ module.exports = [
       {ext: 'gko', cad: c._CAD_ALTIUM},
       {ext: 'fab', cad: c._CAD_ORCAD},
       {ext: 'drd', cad: c._CAD_ORCAD},
-      {ext: 'outline\\.gbr', cad: c._CAD_GEDA_PCB},
+      {match: /outline/, cad: [c._CAD_GEDA_PCB, c._CAD_EAGLE_PCBNG]},
       {match: /boardoutline/, cad: [c._CAD_EAGLE_OSHPARK, c._CAD_DIPTRACE]},
       {match: /edge[._]cuts/, cad: c._CAD_KICAD},
       {match: /profile/, cad: c._CAD_EAGLE},
@@ -163,9 +202,10 @@ module.exports = [
       {ext: 'drl', cad: [c._CAD_KICAD, c._CAD_DIPTRACE]},
       {ext: 'tap', cad: c._CAD_ORCAD},
       {ext: 'npt', cad: c._CAD_ORCAD},
-      {ext: 'fab\\.gbr', cad: c._CAD_GEDA_PCB},
       {ext: 'plated-drill\\.cnc', cad: c._CAD_GEDA_PCB},
+      {match: /fab/, cad: c._CAD_GEDA_PCB},
       {match: /npth/, cad: c._CAD_KICAD},
+      {match: '/drill/', cad: c._CAD_EAGLE_PCBNG},
     ],
   },
   {
@@ -173,7 +213,9 @@ module.exports = [
     side: null,
     matchers: [
       {ext: 'pos', cad: c._CAD_KICAD},
+      {ext: 'art', cad: c._CAD_ALLEGRO},
       {ext: 'gbr', cad: null},
+      {ext: 'gbx', cad: null},
       {ext: 'ger', cad: null},
       {ext: 'pho', cad: null},
     ],

--- a/packages/whats-that-gerber/lib/matchers.js
+++ b/packages/whats-that-gerber/lib/matchers.js
@@ -17,7 +17,6 @@ function layerTypeToMatchers(layer) {
 
     function mergeLayerWithCad(cad) {
       return {
-        id: layer.id,
         type: layer.type,
         side: layer.side,
         match: match,


### PR DESCRIPTION
Closes #246, closes #248. See those tickets for background.

Importantly for future work: this PR sets up a whats-that-gerber blacklist. At the moment it's causing wtg to ignore Eagle metadata files (.gpi, .dri) but hopefully can be extended for other stuff in the future that are commonly included in board bundles that could cause false hits with the Gerber matchers