### PR TITLE
Identify Plated/Non Plated holes in Drill File

### DIFF
--- a/packages/gerber-parser/API.md
+++ b/packages/gerber-parser/API.md
@@ -185,17 +185,18 @@ Commands used to set the state of the plotter.
 }
 ```
 
-| property      | value               | description                             |
-| ------------- | ------------------- | --------------------------------------- |
-| `mode`        | `i`, `cw`, or `ccw` | linear, CW-arc, or CCW-arc draw mode    |
-| `arc`         | `s` or `m`          | single or multi-quadrant arc mode       |
-| `region`      | `true` or `false`   | region mode on or off                   |
-| `units`       | `mm` or `in`        | units                                   |
-| `backupUnits` | `mm` or `in`        | backup units (used if units missing)    |
-| `epsilon`     | `[Number]`          | threshold for comparing two coordinates |
-| `nota`        | `A` or `I`          | absolute or incremental coord notation  |
-| `backupNota`  | `A` or `I`          | backup notation (used if missing)       |
-| `tool`        | `[Integer string]`  | currently used tool code                |
+| property      | value               | description                                                  |
+| ------------- | ------------------- | ------------------------------------------------------------ |
+| `mode`        | `i`, `cw`, or `ccw` | linear, CW-arc, or CCW-arc draw mode                         |
+| `arc`         | `s` or `m`          | single or multi-quadrant arc mode                            |
+| `region`      | `true` or `false`   | region mode on or off                                        |
+| `units`       | `mm` or `in`        | units                                                        |
+| `backupUnits` | `mm` or `in`        | backup units (used if units missing)                         |
+| `epsilon`     | `[Number]`          | threshold for comparing two coordinates                      |
+| `nota`        | `A` or `I`          | absolute or incremental coord notation                       |
+| `backupNota`  | `A` or `I`          | backup notation (used if missing)                            |
+| `tool`        | `[Integer string]`  | currently used tool code                                     |
+| `holePlating` | `pth` or `npth`     | Plated or Non-Plated through-holes for Altium NC-Drill Files |
 
 ### operation objects
 

--- a/packages/gerber-parser/lib/_parse-drill.js
+++ b/packages/gerber-parser/lib/_parse-drill.js
@@ -70,6 +70,7 @@ var parseCommentForFormatHints = function(parser, block, line) {
   } else if (RE_ALTIUM_NPTH.test(block)) {
     parser._push(commands.set('plating', 'NPTH', line))
   }
+
   return result
 }
 

--- a/packages/gerber-parser/lib/_parse-drill.js
+++ b/packages/gerber-parser/lib/_parse-drill.js
@@ -66,7 +66,7 @@ var parseCommentForFormatHints = function(parser, block, line) {
     result.places = [Number(altiumMatch[1]), Number(altiumMatch[2])]
   } else if (RE_ALTIUM_PLATING_HINT.test(block)) {
     var platingMatch = block.match(RE_ALTIUM_PLATING_HINT)
-    var holePlating = platingMatch[1] === 'PLATED' ? 'pth' : 'npth';
+    var holePlating = platingMatch[1] === 'PLATED' ? 'pth' : 'npth'
     parser._push(commands.set('holePlating', holePlating, line))
   }
 

--- a/packages/gerber-parser/lib/_parse-drill.js
+++ b/packages/gerber-parser/lib/_parse-drill.js
@@ -10,6 +10,8 @@ var normalize = require('./normalize-coord')
 var parseCoord = require('./parse-coord')
 
 var RE_ALTIUM_HINT = /;FILE_FORMAT=(\d):(\d)/
+var RE_ALTIUM_PTH = /;TYPE=PLATED/
+var RE_ALTIUM_NPTH = /;TYPE=NON_PLATED/
 var RE_KI_HINT = /;FORMAT={(.):(.)\/ (absolute|.+)? \/ (metric|inch) \/.+(trailing|leading|decimal|keep)/
 
 var RE_UNITS = /^(INCH|METRIC|M71|M72)/
@@ -63,8 +65,11 @@ var parseCommentForFormatHints = function(parser, block, line) {
     var altiumMatch = block.match(RE_ALTIUM_HINT)
 
     result.places = [Number(altiumMatch[1]), Number(altiumMatch[2])]
+  } else if (RE_ALTIUM_PTH.test(block)) {
+    parser._push(commands.set('plating', 'PTH', line))
+  } else if (RE_ALTIUM_NPTH.test(block)) {
+    parser._push(commands.set('plating', 'NPTH', line))
   }
-
   return result
 }
 

--- a/packages/gerber-parser/lib/_parse-drill.js
+++ b/packages/gerber-parser/lib/_parse-drill.js
@@ -10,8 +10,7 @@ var normalize = require('./normalize-coord')
 var parseCoord = require('./parse-coord')
 
 var RE_ALTIUM_HINT = /;FILE_FORMAT=(\d):(\d)/
-var RE_ALTIUM_PTH = /;TYPE=PLATED/
-var RE_ALTIUM_NPTH = /;TYPE=NON_PLATED/
+var RE_ALTIUM_PLATING_HINT = /;TYPE=(PLATED|NON_PLATED)/
 var RE_KI_HINT = /;FORMAT={(.):(.)\/ (absolute|.+)? \/ (metric|inch) \/.+(trailing|leading|decimal|keep)/
 
 var RE_UNITS = /^(INCH|METRIC|M71|M72)/
@@ -65,10 +64,10 @@ var parseCommentForFormatHints = function(parser, block, line) {
     var altiumMatch = block.match(RE_ALTIUM_HINT)
 
     result.places = [Number(altiumMatch[1]), Number(altiumMatch[2])]
-  } else if (RE_ALTIUM_PTH.test(block)) {
-    parser._push(commands.set('plating', 'PTH', line))
-  } else if (RE_ALTIUM_NPTH.test(block)) {
-    parser._push(commands.set('plating', 'NPTH', line))
+  } else if (RE_ALTIUM_PLATING_HINT.test(block)) {
+    var platingMatch = block.match(RE_ALTIUM_PLATING_HINT)
+    var holePlating = platingMatch[1] === 'PLATED' ? 'pth' : 'npth';
+    parser._push(commands.set('holePlating', holePlating, line))
   }
 
   return result

--- a/packages/gerber-parser/test/gerber-parser_drill_test.js
+++ b/packages/gerber-parser/test/gerber-parser_drill_test.js
@@ -608,15 +608,15 @@ describe('gerber parser with drill files', function() {
 
   describe('parsing altium plating comments', function() {
     it('should set hole plating', function(done) {
-        var expected = [
-          {type:'set', line:1, prop:'holePlating', value:'pth' },
-          {type:'set', line:2, prop:'holePlating', value:'npth'}
-        ]
+      var expected = [
+        {type: 'set', line: 1, prop: 'holePlating', value: 'pth'},
+        {type: 'set', line: 2, prop: 'holePlating', value: 'npth'},
+      ]
 
-        expectResults(expected, done)
-        p.write(';TYPE=PLATED\n')
-        p.write(';TYPE=NON_PLATED\n')
-        p.end()
+      expectResults(expected, done)
+      p.write(';TYPE=PLATED\n')
+      p.write(';TYPE=NON_PLATED\n')
+      p.end()
     })
   })
 })

--- a/packages/gerber-parser/test/gerber-parser_drill_test.js
+++ b/packages/gerber-parser/test/gerber-parser_drill_test.js
@@ -605,4 +605,18 @@ describe('gerber parser with drill files', function() {
       })
     })
   })
+
+  describe('parsing altium plating comments', function() {
+    it('should set hole plating', function(done) {
+        var expected = [
+          {type:'set', line:1, prop:'holePlating', value:'pth' },
+          {type:'set', line:2, prop:'holePlating', value:'npth'}
+        ]
+
+        expectResults(expected, done)
+        p.write(';TYPE=PLATED\n')
+        p.write(';TYPE=NON_PLATED\n')
+        p.end()
+    })
+  })
 })


### PR DESCRIPTION
Hi,

My company is using Tracespace for parsing Altium Gerber files and came across the need to differentiate between plated and non-plated holes.

We thought you might like to include this change in the main Tracespace codebase.

Example Drill file:
```
M48
;Layer_Color=9474304
;FILE_FORMAT=4:4
METRIC,TZ
;TYPE=PLATED
T1F00S00C0.3000
T2F00S00C0.9000
...
```

This change will add the 'plating' property to the output hole definitions:

```
{
  "tools": {
    "T01": {
      "id": "T01",
      "size": 0.2,
      "plating": "PTH"
    },
    ...
}
```


