### PR TITLE
chore(renovate): Group all dependency updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,9 @@
   "postUpdateOptions": ["npmDedupe"],
   "packageRules": [
     {
-      "depTypeList": ["peerDependencies"],
-      "rangeStrategy": "widen"
+      "groupName": "dependencies",
+      "depTypeList": ["dependencies"],
+      "separateMajorMinor": true
     },
     {
       "groupName": "devDependencies",
@@ -13,17 +14,13 @@
       "separateMajorMinor": false
     },
     {
-      "groupName": "type definitions",
-      "packagePatterns": ["^@types/"]
+      "groupName": "peerDependencies",
+      "depTypeList": ["peerDependencies"],
+      "rangeStrategy": "widen"
     },
     {
-      "groupName": "react monorepo and packages",
-      "extends": ["monorepo:react"],
-      "packageNames": [
-        "react-hot-loader",
-        "@hot-loader/react-dom",
-        "react-transition-group"
-      ]
+      "groupName": "type definitions",
+      "packagePatterns": ["^@types/"]
     }
   ]
 }


### PR DESCRIPTION
Given my contribution patterns to this repo (i.e. whenever I have free time), there are too many Renovate PRs for me to merge without burning all my tracespace time on dependency management. This PR groups all bumps together into one PR per dependency type.

I think this will be more manageable and is honestly what I usually end up doing manually anyway