### PR TITLE
doc(pcb-stackup): fix usage example in README

### DIFF
--- a/packages/pcb-stackup/README.md
+++ b/packages/pcb-stackup/README.md
@@ -76,7 +76,7 @@ const fileNames = [
 
 const layers = fileNames.map(filename => ({
   filename,
-  gerber: fs.createReadStream(path),
+  gerber: fs.createReadStream(filename),
 }))
 
 pcbStackup(layers).then(stackup => {


### PR DESCRIPTION
`path` is not defined in this context, change to use `filename` instead