### PR TITLE
fix(view): Ensure layer defs are accessible to <mask>s in board renders

### DIFF
--- a/apps/view/src/BoardDisplay/index.tsx
+++ b/apps/view/src/BoardDisplay/index.tsx
@@ -58,7 +58,7 @@ export default function BoardDisplay(): JSX.Element {
                 source={board.bottom}
               />
               <LayersRender
-                className={cx('w-100', {dn: mode !== 'layers'})}
+                className={cx('w-100', {clip: mode !== 'layers'})}
                 viewBox={board.viewBox}
                 layers={board.layers}
                 layerVisibility={layerVisibility}


### PR DESCRIPTION
Previously, when one of the board renders was selected, the layers render was set to `display: none`. This made any `<mask>`s referenced in the board renders fail to load, because the `mask="url(#some_mask_id)"` attribute would no longer resolve.

This PR switches the hiding mechanism for the layers view from `display: none` to clipping.

Fixes #303