### PR TITLE
fix(cli): fix cli file path resolution on Windows

### DIFF
--- a/packages/cli/lib/cli.js
+++ b/packages/cli/lib/cli.js
@@ -5,7 +5,6 @@ const path = require('path')
 const util = require('util')
 const common = require('common-prefix')
 const {get} = require('dot-prop')
-const glob = require('globby')
 const makeDir = require('make-dir')
 const debug = require('debug')('@tracespace/cli')
 
@@ -17,7 +16,7 @@ const yargs = require('yargs')
 const {description, version} = require('../package.json')
 const examples = require('./examples')
 const options = require('./options')
-const resolve = require('./resolve')
+const {resolvePatterns} = require('./resolve')
 
 const writeFile = util.promisify(fs.writeFile)
 const stackup = util.promisify(pcbStackup)
@@ -26,7 +25,6 @@ module.exports = function cli(processArgv, config) {
   const argv = yargs
     .usage('$0 [options] <files...>', `${description}\nv${version}`, yargs => {
       yargs.positional('files', {
-        coerce: files => files.map(resolve),
         describe:
           "Filenames, directories, or globs to a PCB's Gerber/drill files",
         type: 'string',
@@ -55,7 +53,7 @@ module.exports = function cli(processArgv, config) {
 
   if (config._configFile) info(`Config loaded from ${config._configFile}`)
 
-  return glob(argv.files)
+  return resolvePatterns(argv.files)
     .then(renderFiles)
     .then(writeRenders)
 

--- a/packages/cli/lib/options.js
+++ b/packages/cli/lib/options.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const resolve = require('./resolve')
+const {normalize} = require('./resolve')
 
 const STDOUT = '-'
 
@@ -8,7 +8,7 @@ module.exports = {
   out: {
     STDOUT,
     alias: 'o',
-    coerce: path => (path === STDOUT ? path : resolve(path)),
+    coerce: path => (path === STDOUT ? path : normalize(path)),
     default: '.',
     describe: `Output directory (or \`${STDOUT}\` for stdout)`,
     type: 'string',

--- a/packages/cli/lib/resolve.js
+++ b/packages/cli/lib/resolve.js
@@ -22,7 +22,9 @@ function resolvePatterns(patterns) {
 
   return matchPatterns.then(matches => {
     debug('glob matches', matches)
-    return files.concat(matches.filter(m => files.indexOf(m) === -1))
+
+    // TODO(mc, 2020-04-30): ensure results are deduped
+    return files.concat(matches)
   })
 }
 

--- a/packages/cli/lib/resolve.js
+++ b/packages/cli/lib/resolve.js
@@ -1,8 +1,29 @@
 'use strict'
 
 const path = require('path')
+const globby = require('globby')
+const isGlob = require('is-glob')
+const slash = require('slash')
 const untildify = require('untildify')
+const debug = require('debug')('@tracespace/cli')
 
-module.exports = function resolve(filename) {
-  return path.resolve(process.cwd(), untildify(filename))
+function normalize(filename) {
+  return path.normalize(untildify(filename))
 }
+
+function resolvePatterns(patterns) {
+  const normalized = patterns.map(normalize)
+  const files = normalized.filter(p => !isGlob(slash(p)))
+  const globs = normalized.map(slash).filter(isGlob)
+
+  debug('patterns', patterns, 'mapped to files', files, 'and globs', globs)
+
+  const matchPatterns = globs.length > 0 ? globby(globs) : Promise.resolve([])
+
+  return matchPatterns.then(matches => {
+    debug('glob matches', matches)
+    return files.concat(matches.filter(m => files.indexOf(m) === -1))
+  })
+}
+
+module.exports = {normalize, resolvePatterns}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,8 +38,10 @@
     "dot-prop": "^5.1.0",
     "gerber-to-svg": "^4.2.0",
     "globby": "^10.0.2",
+    "is-glob": "^4.0.1",
     "make-dir": "^3.0.0",
     "pcb-stackup": "^4.2.0",
+    "slash": "^3.0.0",
     "untildify": "^4.0.0",
     "whats-that-gerber": "^4.2.0",
     "yargs": "^15.1.0"


### PR DESCRIPTION
The input file resolution for the CLI was a little too clever, and attempted to resolve everything to absolute paths while replacing `~`s with the home directory and then passing everything into `globby` to also get any glob patterns. Unfortunately, [`globby` does not support Windows file paths](https://github.com/sindresorhus/globby#api), which meant that on Windows, any input file would be resolved to an absolute Windows path, which `globby` would fail to match with any files.

This PR:

- Gets rid of the explicit resolve to `process.cwd` because it's redundant
- Only passes things that look like globs to globby, otherwise treats them like files
- Makes sure that any glob patterns have their path separators switched to POSIX-style

Fixes #327