### PR TITLE
pass parse error within stream processing to done callback

### DIFF
--- a/packages/gerber-parser/lib/parser.js
+++ b/packages/gerber-parser/lib/parser.js
@@ -73,10 +73,13 @@ Parser.prototype._transform = function(chunk, encoding, done) {
   chunk = this._stash + chunk
   this._stash = ''
 
-  this._process(chunk, filetype)
-
-  this._index = 0
-  done()
+  try {
+    this._process(chunk, filetype)
+    this._index = 0
+    done()
+  } catch (error) {
+    done(error)
+  }
 }
 
 Parser.prototype._flush = function(done) {


### PR DESCRIPTION
When an error is thrown within `_process` in gerber-parser, the error is being thrown directly rather than being passed to `done`, which makes it so that there is no way to catch/handle the error. This PR just wraps the call to `_process` in a try/catch and passes the error to `done`, so that it can be handled with `stream.on('error', handleError)`.

In case it matters for another reason, I discovered this issue when a file with the line`X1406700Y1350150D02*` was streamed to gerber-parser, which triggered this error: https://github.com/tracespace/tracespace/blob/8284329c76fe7711ed70bb837ef5cb1a83ba4b0f/packages/gerber-parser/lib/parse-coord.js#L25