### PR TITLE
Start publishing v5 pre-releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: publish
+on:
+  push:
+    # TODO(mc, 2020-06-28): switch to do all releases
+    tags: v5.*
+
+jobs:
+  test:
+    name: pre-publish test run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+
+  publish:
+    name: publish to npm
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn install --frozen-lockfile
+      - run: yarn build:all
+      - name: publish to npm with lerna
+        # use npm to run publish script for reliability
+        run: npm run publish:npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Bug Fixes
+
+* **deps:** update devDependencies, React, and yargs ([#315](https://github.com/tracespace/tracespace/issues/315)) ([34ebb3e](https://github.com/tracespace/tracespace/commit/34ebb3e))
+* **view:** avoid lowercase sentence start in welcome message ([8b7f331](https://github.com/tracespace/tracespace/commit/8b7f331))
+* **view:** fix react hook and typescript lint failures ([4e8f300](https://github.com/tracespace/tracespace/commit/4e8f300))
+
+
+### chore
+
+* drop support for Node v8 ([8523152](https://github.com/tracespace/tracespace/commit/8523152))
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+* **xml-id:** port xml-id to TypeScript ([ff4bbb1](https://github.com/tracespace/tracespace/commit/ff4bbb1))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* Node v8 is no longer supported
+* **xml-id:** Export scheme of xml-id slightly changed
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/README.md
+++ b/README.md
@@ -161,16 +161,16 @@ Arduino Uno design files used under the terms of the [Creative Commons Attributi
 <!-- npm links -->
 
 [cli npm]: https://www.npmjs.com/package/@tracespace/cli
-[parser npm]: #
-[xml-id npm]: https://www.npmjs.com/package/@tracespace/cli
-[wtg npm]: https://www.npmjs.com/package/whats-that-gerber
+[parser npm]: https://www.npmjs.com/package/@tracespace/parser/v/next
+[xml-id npm]: https://www.npmjs.com/package/@tracespace/xml-id/v/next
+[wtg npm]: https://www.npmjs.com/package/whats-that-gerber/v/next
 
 <!-- npm version badges -->
 
 [cli npm badge]: https://flat.badgen.net/npm/v/@tracespace/cli
-[parser npm badge]: https://flat.badgen.net/badge/npm/wip/orange
-[xml-id npm badge]: https://flat.badgen.net/npm/v/@tracespace/xml-id
-[wtg npm badge]: https://flat.badgen.net/npm/v/whats-that-gerber
+[parser npm badge]: https://flat.badgen.net/npm/v/@tracespace/parser/next
+[xml-id npm badge]: https://flat.badgen.net/npm/v/@tracespace/xml-id/next
+[wtg npm badge]: https://flat.badgen.net/npm/v/whats-that-gerber/next
 
 <!-- dependency links -->
 
@@ -188,13 +188,13 @@ Arduino Uno design files used under the terms of the [Creative Commons Attributi
 
 <!-- bundle size links -->
 
-[parser size]: #
+[parser size]: https://bundlephobia.com/result?p=@tracespace/parser
 [xml-id size]: https://bundlephobia.com/result?p=@tracespace/xml-id
 [wtg size]: https://bundlephobia.com/result?p=whats-that-gerber
 
 <!-- bundle size badge -->
 
-[parser size badge]: https://flat.badgen.net/badge/minzipped%20size/wip/orange
+[parser size badge]: https://flat.badgen.net/bundlephobia/minzip/@tracespace/parser
 [xml-id size badge]: https://flat.badgen.net/bundlephobia/minzip/@tracespace/xml-id
 [wtg size badge]: https://flat.badgen.net/bundlephobia/minzip/whats-that-gerber
 

--- a/apps/view/CHANGELOG.md
+++ b/apps/view/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Bug Fixes
+
+* **deps:** update devDependencies, React, and yargs ([#315](https://github.com/tracespace/tracespace/issues/315)) ([34ebb3e](https://github.com/tracespace/tracespace/commit/34ebb3e))
+* **view:** avoid lowercase sentence start in welcome message ([8b7f331](https://github.com/tracespace/tracespace/commit/8b7f331))
+* **view:** fix react hook and typescript lint failures ([4e8f300](https://github.com/tracespace/tracespace/commit/4e8f300))
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+* **xml-id:** port xml-id to TypeScript ([ff4bbb1](https://github.com/tracespace/tracespace/commit/ff4bbb1))
+
+
+### BREAKING CHANGES
+
+* **xml-id:** Export scheme of xml-id slightly changed
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/apps/view/package.json
+++ b/apps/view/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tracespace/view",
   "productName": "tracespace view",
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "private": true,
   "description": "Probably the best Gerber viewer on the internet",
   "author": {
@@ -29,7 +29,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.5",
     "@hot-loader/react-dom": "^16.10.2",
-    "@tracespace/xml-id": "^4.0.0",
+    "@tracespace/xml-id": "^5.0.0-next.0",
     "@types/classnames": "^2.2.9",
     "@types/common-prefix": "^1.1.0",
     "@types/core-js": "^2.5.2",
@@ -50,15 +50,15 @@
     "file-saver": "^2.0.2",
     "filereader-stream": "^2.0.0",
     "formik": "^1.5.8",
-    "gerber-parser": "^4.2.0",
-    "gerber-plotter": "^4.2.0",
-    "gerber-to-svg": "^4.2.0",
+    "gerber-parser": "^5.0.0-next.0",
+    "gerber-plotter": "^5.0.0-next.0",
+    "gerber-to-svg": "^5.0.0-next.0",
     "jszip": "^3.2.2",
     "md5.js": "^1.3.5",
     "mini-svg-data-uri": "^1.1.3",
     "mixpanel-browser": "^2.29.1",
-    "pcb-stackup": "^4.2.0",
-    "pcb-stackup-core": "^4.2.0",
+    "pcb-stackup": "^5.0.0-next.0",
+    "pcb-stackup-core": "^5.0.0-next.0",
     "pump": "^3.0.0",
     "randomcolor": "^0.5.4",
     "react": "^16.13.1",
@@ -67,6 +67,6 @@
     "react-transition-group": "^4.4.1",
     "tachyons": "^4.11.1",
     "viewbox": "^1.0.0",
-    "whats-that-gerber": "^4.2.0"
+    "whats-that-gerber": "^5.0.0-next.0"
   }
 }

--- a/config/CHANGELOG.md
+++ b/config/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+* **xml-id:** port xml-id to TypeScript ([ff4bbb1](https://github.com/tracespace/tracespace/commit/ff4bbb1))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* **xml-id:** Export scheme of xml-id slightly changed
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/config/package.json
+++ b/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tracespace/config",
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "private": true,
   "description": "Development config for tracespace/tracespace",
   "author": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "example": "lerna run example",
     "prebump": "yarn test",
     "bump": "lerna version",
-    "publish:npm": "lerna publish from-git --yes --npm-tag $NPM_TAG",
+    "publish:npm": "lerna publish from-git --yes --npm-tag next",
     "publish:s3": "node ./scripts/publish-to-s3 apps/www/dist: apps/view/dist:view"
   },
   "config": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Bug Fixes
+
+* **deps:** update devDependencies, React, and yargs ([#315](https://github.com/tracespace/tracespace/issues/315)) ([34ebb3e](https://github.com/tracespace/tracespace/commit/34ebb3e))
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Render a PCB as SVGs from the command line",
   "bin": {
     "tracespace": "bin/cli.js"
@@ -50,12 +50,12 @@
     "cosmiconfig": "^5.2.1",
     "debug": "^4.1.1",
     "dot-prop": "^5.1.0",
-    "gerber-to-svg": "^4.2.0",
+    "gerber-to-svg": "^5.0.0-next.0",
     "globby": "^11.0.1",
     "make-dir": "^3.0.0",
-    "pcb-stackup": "^4.2.0",
+    "pcb-stackup": "^5.0.0-next.0",
     "untildify": "^4.0.0",
-    "whats-that-gerber": "^4.2.0",
+    "whats-that-gerber": "^5.0.0-next.0",
     "yargs": "^15.1.0"
   }
 }

--- a/packages/fixtures/CHANGELOG.md
+++ b/packages/fixtures/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/fixtures/package.json
+++ b/packages/fixtures/package.json
@@ -4,7 +4,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Test fixtures for tracespace projects",
   "main": "index.js",
   "repository": {

--- a/packages/gerber-parser/CHANGELOG.md
+++ b/packages/gerber-parser/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Bug Fixes
+
+* **deps:** update devDependencies, React, and yargs ([#315](https://github.com/tracespace/tracespace/issues/315)) ([34ebb3e](https://github.com/tracespace/tracespace/commit/34ebb3e))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/gerber-parser/package.json
+++ b/packages/gerber-parser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gerber-parser",
   "private": true,
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Streaming Gerber/drill file parser",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/gerber-plotter/CHANGELOG.md
+++ b/packages/gerber-plotter/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Bug Fixes
+
+* **deps:** update devDependencies, React, and yargs ([#315](https://github.com/tracespace/tracespace/issues/315)) ([34ebb3e](https://github.com/tracespace/tracespace/commit/34ebb3e))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/gerber-plotter/package.json
+++ b/packages/gerber-plotter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gerber-plotter",
   "private": true,
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Streaming Gerber / NC drill layer image plotter",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/gerber-to-svg/CHANGELOG.md
+++ b/packages/gerber-to-svg/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Bug Fixes
+
+* **deps:** update devDependencies, React, and yargs ([#315](https://github.com/tracespace/tracespace/issues/315)) ([34ebb3e](https://github.com/tracespace/tracespace/commit/34ebb3e))
+* **view:** fix react hook and typescript lint failures ([4e8f300](https://github.com/tracespace/tracespace/commit/4e8f300))
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+* **xml-id:** port xml-id to TypeScript ([ff4bbb1](https://github.com/tracespace/tracespace/commit/ff4bbb1))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* **xml-id:** Export scheme of xml-id slightly changed
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/gerber-to-svg/package.json
+++ b/packages/gerber-to-svg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gerber-to-svg",
   "private": true,
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Render individual Gerber / NC drill files as SVGs",
   "main": "index.js",
   "types": "index.d.ts",
@@ -37,11 +37,11 @@
   },
   "homepage": "https://github.com/tracespace/tracespace#readme",
   "dependencies": {
-    "@tracespace/xml-id": "^4.0.0",
+    "@tracespace/xml-id": "^5.0.0-next.0",
     "@types/node": "^14.0.14",
     "escape-html": "^1.0.3",
-    "gerber-parser": "^4.2.0",
-    "gerber-plotter": "^4.2.0",
+    "gerber-parser": "^5.0.0-next.0",
+    "gerber-plotter": "^5.0.0-next.0",
     "inherits": "^2.0.4",
     "lodash.isfinite": "^3.3.2",
     "readable-stream": "^3.4.0",

--- a/packages/parser/CHANGELOG.md
+++ b/packages/parser/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -4,7 +4,11 @@ A parser for printed circuit board manufacturing files. Compiles [Gerber][gerber
 
 Part of the [tracespace][] collection of PCB visualization tools.
 
-**This package is still in development and is not yet published**
+**This package is still in development and available as a prerelease**
+
+```shell
+npm install @tracespace/parser@next
+```
 
 [gerber]: https://en.wikipedia.org/wiki/Gerber_format
 [nc-drill]: https://en.wikipedia.org/wiki/PCB_NC_formats

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -10,6 +10,7 @@
   "module": "esm/index.mjs",
   "types": "lib/index.d.ts",
   "unpkg": "umd/parser.min.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tracespace/tracespace.git",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.0.0-unpublished",
+  "version": "5.0.0-next.0",
   "description": "Gerber and NC drill file parser",
   "source": "src/index.ts",
   "main": "cjs/index.js",

--- a/packages/pcb-stackup-core/CHANGELOG.md
+++ b/packages/pcb-stackup-core/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/pcb-stackup-core/package.json
+++ b/packages/pcb-stackup-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pcb-stackup-core",
   "private": true,
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Layer stacking core logic for pcb-stackup",
   "main": "index.js",
   "types": "index.d.ts",
@@ -33,12 +33,12 @@
   },
   "homepage": "https://github.com/tracespace/tracespace",
   "dependencies": {
-    "@tracespace/xml-id": "^4.0.0",
+    "@tracespace/xml-id": "^5.0.0-next.0",
     "@types/node": "^14.0.14",
     "color-string": "^1.5.3",
-    "gerber-to-svg": "^4.2.0",
+    "gerber-to-svg": "^5.0.0-next.0",
     "viewbox": "^1.0.0",
-    "whats-that-gerber": "^4.2.0",
+    "whats-that-gerber": "^5.0.0-next.0",
     "xml-element-string": "^1.0.0",
     "xtend": "^4.0.2"
   }

--- a/packages/pcb-stackup/CHANGELOG.md
+++ b/packages/pcb-stackup/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/pcb-stackup/package.json
+++ b/packages/pcb-stackup/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pcb-stackup",
   "private": true,
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Render PCBs as beautiful, precise SVGs from Gerber / NC drill files",
   "main": "index.js",
   "types": "index.d.ts",
@@ -35,13 +35,13 @@
   },
   "homepage": "https://github.com/tracespace/tracespace",
   "dependencies": {
-    "@tracespace/xml-id": "^4.0.0",
+    "@tracespace/xml-id": "^5.0.0-next.0",
     "@types/node": "^14.0.14",
-    "gerber-to-svg": "^4.2.0",
-    "pcb-stackup-core": "^4.2.0",
+    "gerber-to-svg": "^5.0.0-next.0",
+    "pcb-stackup-core": "^5.0.0-next.0",
     "run-parallel": "^1.1.9",
     "run-waterfall": "^1.1.6",
-    "whats-that-gerber": "^4.2.0",
+    "whats-that-gerber": "^5.0.0-next.0",
     "xtend": "^4.0.2"
   }
 }

--- a/packages/whats-that-gerber/CHANGELOG.md
+++ b/packages/whats-that-gerber/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Code Refactoring
+
+* **whats-that-gerber:** convert WTG to TypeScript ([45056c4](https://github.com/tracespace/tracespace/commit/45056c4))
+* **xml-id:** port xml-id to TypeScript ([ff4bbb1](https://github.com/tracespace/tracespace/commit/ff4bbb1))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* **xml-id:** Export scheme of xml-id slightly changed
+* **whats-that-gerber:** Switched WTG to named exports only
+
+
+
+
+
 # [4.2.0](https://github.com/tracespace/tracespace/compare/v4.1.1...v4.2.0) (2019-10-10)
 
 

--- a/packages/whats-that-gerber/package.json
+++ b/packages/whats-that-gerber/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whats-that-gerber",
-  "version": "4.2.0",
+  "version": "5.0.0-next.0",
   "description": "Identify Gerber and drill files by filename",
   "source": "src/index.ts",
   "main": "cjs/index.js",

--- a/packages/xml-id/CHANGELOG.md
+++ b/packages/xml-id/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [5.0.0-next.0](https://github.com/tracespace/tracespace/compare/v4.2.0...v5.0.0-next.0) (2020-06-28)
+
+
+### Code Refactoring
+
+* **xml-id:** port xml-id to TypeScript ([ff4bbb1](https://github.com/tracespace/tracespace/commit/ff4bbb1))
+
+
+### Features
+
+* **parser:** add @tracespace/parser package ([#338](https://github.com/tracespace/tracespace/issues/338)) ([6f974dd](https://github.com/tracespace/tracespace/commit/6f974dd))
+
+
+### BREAKING CHANGES
+
+* **xml-id:** Export scheme of xml-id slightly changed
+
+
+
+
+
 # [4.0.0](https://github.com/tracespace/tracespace/compare/v4.0.0-next.19...v4.0.0) (2019-03-09)
 
 **Note:** Version bump only for package @tracespace/xml-id

--- a/packages/xml-id/package.json
+++ b/packages/xml-id/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.0.0",
+  "version": "5.0.0-next.0",
   "description": "XML ID generation and sanitation utilities",
   "source": "src/index.ts",
   "main": "cjs/index.js",


### PR DESCRIPTION
This PR updates CI configuration and documentation to start publishing v5 pre-releases under the `next` tag on npm. So far, this includes:

- TypeScript rewrite of whats-that-gerber
- TypeScript rewrite of @tracespace/xml-id
- gerber-parser replacement library @tracespace/parser