### PR TITLE
fix: accept negative tool mods and macro expression args for outline primities

### DIFF
--- a/packages/gerber-parser/lib/_parse-gerber.js
+++ b/packages/gerber-parser/lib/_parse-gerber.js
@@ -28,7 +28,7 @@ var RE_UNITS = /^%MO(IN|MM)/
 var RE_FORMAT = /^%FS([LT]?)([AI]?)(.*)X([0-7])([0-7])Y\4\5/
 var RE_POLARITY = /^%LP([CD])/
 var RE_STEP_REP = /^%SR(?:X(\d+)Y(\d+)I([\d.]+)J([\d.]+))?/
-var RE_TOOL_DEF = /^%ADD0*(\d{2,})([A-Za-z_$][\w\-.]*)(?:,((?:X?[\d.]+)*))?/
+var RE_TOOL_DEF = /^%ADD0*(\d{2,})([A-Za-z_$][\w\-.]*)(?:,((?:X?[\d.-]+)*))?/
 var RE_MACRO = /^%AM([A-Za-z_$][\w\-.]*)\*?(.*)/
 
 var parseToolDef = function(parser, block) {

--- a/packages/gerber-parser/lib/_parse-macro-block.js
+++ b/packages/gerber-parser/lib/_parse-macro-block.js
@@ -102,8 +102,8 @@ var parseMacroBlock = function(parser, block) {
     return {
       type: 'outline',
       exp: exp,
-      points: mods.slice(3, -1).map(Number),
-      rot: Number(mods[mods.length - 1]),
+      points: mods.slice(3, -1),
+      rot: mods[mods.length - 1],
     }
   }
 

--- a/packages/gerber-parser/test/gerber-parser_gerber_test.js
+++ b/packages/gerber-parser/test/gerber-parser_gerber_test.js
@@ -417,6 +417,16 @@ describe('gerber parser with gerber files', function() {
       expectResults(expected, done)
       p.write('%ADD0010C,1*%\n')
     })
+
+    it('should handle tool defs with negative modifiers', function(done) {
+      var expectedTools = [{shape: 'CIRC', params: [1, -0.5, 3], hole: []}]
+      var expected = [
+        {type: 'tool', line: 0, code: '10', tool: expectedTools[0]},
+      ]
+
+      expectResults(expected, done)
+      p.write('%ADD10CIRC,1X-0.5X3*%\n')
+    })
   })
 
   describe('aperture macros', function() {
@@ -765,7 +775,7 @@ describe('gerber parser with gerber files', function() {
       })
     })
 
-    it('should parse params in primitives as expressions', function(done) {
+    it('should parse params in circle primitives as expressions', function(done) {
       p.once('data', function(d) {
         expect(d.blocks[0].dia({$1: 4})).to.equal(5)
         done()
@@ -773,6 +783,34 @@ describe('gerber parser with gerber files', function() {
 
       p.write('%AMCIRC1*\n')
       p.write('1,1,$1+1,1,2*%\n')
+    })
+
+    it('should parse params in outline primitives as expressions', function(done) {
+      p.once('data', function(d) {
+        var block = d.blocks[0]
+        var points = block.points
+        var rotation = block.rot
+        var mods = {
+          $1: 0,
+          $2: 1,
+          $3: 2,
+          $4: 3,
+          $5: 4,
+          $6: 5,
+          $7: 6,
+          $8: 7,
+          $9: 8,
+        }
+
+        points.forEach(function(p, i) {
+          expect(p(mods)).to.equal(i)
+        })
+        expect(rotation(mods)).to.equal(8)
+        done()
+      })
+
+      p.write('%AMOUT1*\n')
+      p.write('4,1,3,$1,$2,$3,$4,$5,$6,$7,$8,$9**%\n')
     })
   })
 

--- a/packages/gerber-plotter/lib/_pad-shape.js
+++ b/packages/gerber-plotter/lib/_pad-shape.js
@@ -239,14 +239,18 @@ var runMacro = function(mods, blocks) {
     if (block.type !== 'variable' && block.type !== 'comment') {
       block = Object.keys(block).reduce(function(result, key) {
         var value = block[key]
-
-        if (isFunction(value)) {
-          result[key] = value(mods)
-        } else {
-          result[key] = value
-        }
-
+        result[key] = resolveValue(value)
         return result
+
+        function resolveValue(v) {
+          if (Array.isArray(v)) {
+            return v.map(resolveValue)
+          } else if (isFunction(v)) {
+            return v(mods)
+          } else {
+            return v
+          }
+        }
       }, {})
     }
 

--- a/packages/gerber-plotter/test/gerber-plotter_test.js
+++ b/packages/gerber-plotter/test/gerber-plotter_test.js
@@ -1166,6 +1166,64 @@ describe('gerber plotter', function() {
         expect(p._tool.pad).to.eql([{type: 'circle', cx: 3, cy: 2, r: 2}])
       })
 
+      it('should handle modifiers and functional array args', function() {
+        var blocks = [
+          {
+            type: 'outline',
+            exp: 1,
+            points: [
+              function(mods) {
+                return mods.$1
+              },
+              function(mods) {
+                return mods.$2
+              },
+              function(mods) {
+                return mods.$3
+              },
+              function(mods) {
+                return mods.$4
+              },
+              function(mods) {
+                return mods.$5
+              },
+              function(mods) {
+                return mods.$6
+              },
+              function(mods) {
+                return mods.$7
+              },
+              function(mods) {
+                return mods.$8
+              },
+            ],
+            rot: function(mods) {
+              return mods.$9
+            },
+          },
+        ]
+        var mods = [0, 0, 1, 0, 1, 1, 0]
+        var macro = {type: 'macro', name: 'OUT', blocks: blocks}
+        var tool = {
+          type: 'tool',
+          code: '10',
+          tool: {shape: 'OUT', params: mods, hole: []},
+        }
+
+        p.write(macro)
+        p.write(tool)
+        expect(p._tool.pad).to.eql([
+          {
+            type: 'poly',
+            points: [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+            ],
+          },
+        ])
+      })
+
       it('should handle multiple primitives and exposure', function() {
         var blocks = [
           {type: 'circle', exp: 1, dia: 4, cx: -2, cy: 0, rot: 0},


### PR DESCRIPTION
This PR fixes #345. There were three separate bugs that combined to produce the bad output reported:

- The parser did not know how to handle negative tool modifiers in `%AD` tool definitions
- The parser, for outline primitives in particular, did not allow macro expressions to be used as parameters to the primitive
- The plotter did not know how to plot an outline primitive using macro expressions as its parameters