### PR TITLE
fix(parser): accept units on same line as format

### DIFF
--- a/packages/gerber-parser/lib/_parse-gerber.js
+++ b/packages/gerber-parser/lib/_parse-gerber.js
@@ -178,14 +178,15 @@ var parse = function(parser, block) {
       )
     }
 
-    if (RE_CADENCE_ALLEGRO_UNITS_IN_FORMAT.test(block)) {
-      var caUnitsMatch = block.match(RE_CADENCE_ALLEGRO_UNITS_IN_FORMAT)[1]
-      return parseUnits(parser, caUnitsMatch)
-    }
-
     var epsilon = 1.5 * Math.pow(10, -format.places[1])
     parser._push(commands.set('nota', nota))
     parser._push(commands.set('epsilon', epsilon))
+
+    if (RE_CADENCE_ALLEGRO_UNITS_IN_FORMAT.test(block)) {
+      var caUnitsMatch = block.match(RE_CADENCE_ALLEGRO_UNITS_IN_FORMAT)[1]
+      parseUnits(parser, caUnitsMatch)
+    }
+
     return
   }
 

--- a/packages/gerber-parser/lib/_parse-gerber.js
+++ b/packages/gerber-parser/lib/_parse-gerber.js
@@ -140,7 +140,7 @@ var parse = function(parser, block) {
 
   if (RE_UNITS.test(block)) {
     var unitsMatch = block.match(RE_UNITS)[1]
-    return parseUnits(parser, unitsMatch);
+    return parseUnits(parser, unitsMatch)
   }
 
   if (RE_BKP_UNITS.test(block)) {
@@ -179,8 +179,8 @@ var parse = function(parser, block) {
     }
 
     if (RE_CADENCE_ALLEGRO_UNITS_IN_FORMAT.test(block)) {
-      var unitsMatch = block.match(RE_CADENCE_ALLEGRO_UNITS_IN_FORMAT)[1]
-      return parseUnits(parser, unitsMatch);
+      var caUnitsMatch = block.match(RE_CADENCE_ALLEGRO_UNITS_IN_FORMAT)[1]
+      return parseUnits(parser, caUnitsMatch)
     }
 
     var epsilon = 1.5 * Math.pow(10, -format.places[1])

--- a/packages/gerber-parser/test/gerber-parser_gerber_test.js
+++ b/packages/gerber-parser/test/gerber-parser_gerber_test.js
@@ -162,6 +162,28 @@ describe('gerber parser with gerber files', function() {
       p.write('%MOMM*%\n')
     })
 
+    // Special Case: Cadence Allegro
+    // The gerber spec says
+    //   "There can be only one extended code command between each pair of ‘%’ delimiters"
+    // Cadence Allegro violates this rule by including the units after the format command
+    //
+    // Sample:
+    //   G04 File Origin:  Cadence Allegro 17.2-S032*
+    //   ...
+    //   %FSLAX25Y25*MOMM*%
+    //   ...
+    //
+    it('should set units if found in same line as format', function(done) {
+      var expected = [
+        {type: 'set', prop: 'units', value: 'in', line: 0},
+        {type: 'set', prop: 'units', value: 'mm', line: 1},
+      ]
+
+      expectResults(expected, done)
+      p.write('%FSLAX25Y25*MOIN*%\n')
+      p.write('%FSLAX25Y25*MOMM*%\n')
+    })
+
     it('should set backup units with G70/1', function(done) {
       var expected = [
         {type: 'set', prop: 'backupUnits', value: 'in', line: 0},

--- a/packages/gerber-parser/test/gerber-parser_gerber_test.js
+++ b/packages/gerber-parser/test/gerber-parser_gerber_test.js
@@ -173,15 +173,37 @@ describe('gerber parser with gerber files', function() {
     //   %FSLAX25Y25*MOMM*%
     //   ...
     //
-    it('should set units if found in same line as format', function(done) {
-      var expected = [
-        {type: 'set', prop: 'units', value: 'in', line: 0},
-        {type: 'set', prop: 'units', value: 'mm', line: 1},
-      ]
+    describe('should set units if found in same line as format', function() {
+      it('should output notation and epsilion then units', function(done) {
+        var expected = [
+          {type: 'set', line: 0, prop: 'nota', value: 'A'},
+          {type: 'set', line: 0, prop: 'epsilon', value: 1.5 * Math.pow(10, -5)},
+          {type: 'set', line: 0, prop: 'units', value: 'in' },
 
-      expectResults(expected, done)
-      p.write('%FSLAX25Y25*MOIN*%\n')
-      p.write('%FSLAX25Y25*MOMM*%\n')
+          {type: 'set', line: 1, prop: 'nota', value: 'A'},
+          {type: 'set', line: 1, prop: 'epsilon', value: 1.5 * Math.pow(10, -5)},
+          {type: 'set', line: 1, prop: 'units', value: 'mm', },
+        ]
+
+        expectResults(expected, done)
+
+        p.write('%FSLAX25Y25*MOIN*%\n') // inches
+        p.write('%FSTAX25Y25*MOMM*%\n') // millimeters
+      })
+
+      it('should still parse format', function() {
+        // Inches
+        p.write('%FSLAX25Y25*MOIN*%\n')
+        expect(p.format.zero).to.equal('L')
+        expect(p.format.places).to.eql([2, 5])
+
+        // Millimeters
+        p.format.zero = null
+        p.format.places = null
+        p.write('%FSTAX37Y37*MOMM*%\n')
+        expect(p.format.zero).to.equal('T')
+        expect(p.format.places).to.eql([3, 7])
+      })
     })
 
     it('should set backup units with G70/1', function(done) {

--- a/packages/gerber-parser/test/gerber-parser_gerber_test.js
+++ b/packages/gerber-parser/test/gerber-parser_gerber_test.js
@@ -175,14 +175,15 @@ describe('gerber parser with gerber files', function() {
     //
     describe('should set units if found in same line as format', function() {
       it('should output notation and epsilion then units', function(done) {
+        var epsilon = 1.5 * Math.pow(10, -5)
         var expected = [
           {type: 'set', line: 0, prop: 'nota', value: 'A'},
-          {type: 'set', line: 0, prop: 'epsilon', value: 1.5 * Math.pow(10, -5)},
-          {type: 'set', line: 0, prop: 'units', value: 'in' },
+          {type: 'set', line: 0, prop: 'epsilon', value: epsilon},
+          {type: 'set', line: 0, prop: 'units', value: 'in'},
 
           {type: 'set', line: 1, prop: 'nota', value: 'A'},
-          {type: 'set', line: 1, prop: 'epsilon', value: 1.5 * Math.pow(10, -5)},
-          {type: 'set', line: 1, prop: 'units', value: 'mm', },
+          {type: 'set', line: 1, prop: 'epsilon', value: epsilon},
+          {type: 'set', line: 1, prop: 'units', value: 'mm'},
         ]
 
         expectResults(expected, done)


### PR DESCRIPTION
Cadence Allegro include the units on the same line as the format.  The gerber spec says
> There can be only one extended code command between each pair of ‘%’ delimiters
but I believe the goal of this repo is to handle variations (as long as they are not harmful)

Here's what it looks like (copied from a customer's file):
```
G04 File Origin:  Cadence Allegro 17.2-S032*
...
%FSLAX25Y25*MOMM*%
```

I commented the code and the test, happy to mod as needed