### PR TITLE
Lint cleanup

### DIFF
--- a/apps/view/src/BoardDisplay/display.ts
+++ b/apps/view/src/BoardDisplay/display.ts
@@ -28,8 +28,8 @@ export const SCALE_STEPS = new Array(SCALE_STEP_COUNT + 1)
 export function zoom(
   prevState: DisplayState,
   delta: number,
-  centerX: number = 0.5,
-  centerY: number = 0.5
+  centerX = 0.5,
+  centerY = 0.5
 ): DisplayState {
   const {x: prevX, y: prevY, step: prevStep} = prevState
   const {scale: prevScale} = getScale(prevStep)

--- a/apps/view/src/BoardSettings/render.tsx
+++ b/apps/view/src/BoardSettings/render.tsx
@@ -171,12 +171,16 @@ type OverrideCheckboxProps = FieldProps & {
   defaultValue: unknown
 }
 
+function emptyBlurHandler(): void {
+  // do nothing
+}
+
 function OverrideCheckbox(props: OverrideCheckboxProps): JSX.Element {
   const {form, defaultValue, label} = props
   const field = {
     ...props.field,
     checked: !!props.field.value,
-    onBlur: () => {},
+    onBlur: emptyBlurHandler,
     onChange: (event: React.ChangeEvent<HTMLInputElement>): void => {
       const value = event.target.checked ? defaultValue : ''
       form.setFieldValue(props.field.name, value)

--- a/apps/view/src/analytics/__tests__/create-event.test.ts
+++ b/apps/view/src/analytics/__tests__/create-event.test.ts
@@ -11,7 +11,7 @@ type Spec = {
   expected: AnalyticsEvent | null
 }
 
-const MockFile = (name: string, type: string = ''): File => {
+const MockFile = (name: string, type = ''): File => {
   const file = {name, type, size: 0, lastModified: 0, slice: () => file}
   return (file as unknown) as File
 }

--- a/apps/view/src/logger.ts
+++ b/apps/view/src/logger.ts
@@ -25,12 +25,16 @@ export const createLogMiddleware = (): Middleware => {
   }
 }
 
+function emptyLogHandler(_message: string, ..._meta: unknown[]): void {
+  // do nothing.
+}
+
 function createLogHandler(level: LogLevel): LogHandler {
   if (!minLevel) minLevel = readLogLevel()
 
   return LEVELS.indexOf(level) >= LEVELS.indexOf(minLevel)
     ? (msg, ...meta) => console[level](`${level}: ${msg}`, ...meta)
-    : () => {}
+    : emptyLogHandler
 }
 
 function readLogLevel(): LogLevel {

--- a/apps/view/src/state/actions.ts
+++ b/apps/view/src/state/actions.ts
@@ -45,7 +45,7 @@ export const appPreferences = (prefs: AppPreferences): Action => ({
 
 export const createBoard = (
   files: Array<File>,
-  dragAndDrop: boolean = false
+  dragAndDrop = false
 ): Action => ({
   type: CREATE_BOARD,
   payload: files,


### PR DESCRIPTION
Resolves some lint warnings.

I opted to define named functions for the no-empty-function rule. The idea is that function ever ended up being used in the wrong context, at least you'd have the name as a hint.

I did not fix the remaining warnings since they involve hooks which i have used hooks. From what I understand of hooks the fixes would be straight forward, but I don't want to risk creating more work right now.

I'm very ok with discarding these commits in favour of tweaking the lint rules:
- allowing empty arrow functions seems ok to me (there's an option for that)
- redundant typing also seems ok, removing these types doesn't alter readability significantly once you are use to read Typescript

...if you'd prefer the rule changes lmk. 

(No need to delay releasing for these changes)
