### PR TITLE
fix(gerber-plotter): allow unset tool when drawing region arcs

### DIFF
--- a/packages/gerber-plotter/lib/_operate.js
+++ b/packages/gerber-plotter/lib/_operate.js
@@ -364,10 +364,15 @@ var interpolate = function(
   pathGraph,
   plotter
 ) {
-  if (!region && tool.trace.length === 0) {
+  var strokableTool = region || (tool && tool.trace.length > 0)
+  var arcableTool = region || (tool && tool.trace.length === 1)
+  var toolCode = tool ? tool.code : '[NO TOOL SET]'
+
+  if (!strokableTool) {
     plotter._warn(
-      'tool ' + tool.code + ' is not strokable; ignoring interpolate'
+      'tool ' + toolCode + ' is not strokable; ignoring interpolate'
     )
+
     return boundingBox.new()
   }
 
@@ -382,8 +387,12 @@ var interpolate = function(
   }
 
   // else, make sure we're allowed to be drawing an arc, then draw an arc
-  if (tool.trace.length !== 1 && !region) {
-    plotter._warn('cannot draw an arc with a non-circular tool')
+  if (!arcableTool) {
+    plotter._warn(
+      'cannot draw arc with non-circular tool ' +
+        toolCode +
+        '; ignoring interpolate'
+    )
     return boundingBox.new()
   }
 

--- a/packages/gerber-plotter/test/gerber-plotter_test.js
+++ b/packages/gerber-plotter/test/gerber-plotter_test.js
@@ -1623,6 +1623,16 @@ describe('gerber plotter', function() {
           expect(p._path.length).to.equal(1)
         })
 
+        it('should allow missing tools if in region mode', function() {
+          p = plotter()
+
+          p.write({type: 'set', prop: 'arc', value: 's'})
+          p.write({type: 'set', prop: 'mode', value: 'cw'})
+          p.write({type: 'set', prop: 'region', value: true})
+          p.write({type: 'op', op: 'int', coord: {x: 2, y: 0, i: 1, j: 1.5}})
+          expect(p._path.length).to.equal(1)
+        })
+
         describe('bounding box', function() {
           it('should usually use the arc end points', function() {
             p.write({type: 'op', op: 'move', coord: {x: 0.5, y: 0.866}})


### PR DESCRIPTION
A conditional in the plotter's `_operate` function was in the incorrect order, preventing valid region arc outlines from being drawn if there was no tool set. This PR improves that guard to allow arcs for missing tools in region mode.

Fixes #355