### PR TITLE
fix(gerber-plotter): do not ignore duplicate tool definitions

### DIFF
--- a/packages/gerber-plotter/lib/plotter.js
+++ b/packages/gerber-plotter/lib/plotter.js
@@ -227,11 +227,7 @@ Plotter.prototype._transform = function(chunk, encoding, done) {
     var toolDef = chunk.tool
 
     if (this._tools[code]) {
-      this._warn(
-        'tool ' + code + ' is already defined; ignoring new definition'
-      )
-
-      return done()
+      this._warn('tool ' + code + ' is already defined; overwriting definition')
     }
 
     var shapeAndBox = padShape(toolDef, this._macros)

--- a/packages/gerber-plotter/test/gerber-plotter_test.js
+++ b/packages/gerber-plotter/test/gerber-plotter_test.js
@@ -278,19 +278,23 @@ describe('gerber plotter', function() {
       expect(p._tool.trace).to.eql([2, 3])
     })
 
-    it('should warn and ignore if the tool has already been set', function(done) {
-      var circle = {shape: 'circle', params: [4], hole: []}
-      var rect = {shape: 'rect', params: [2, 3], hole: []}
+    it('should warn if the tool has already been set', function() {
+      var circle1 = {shape: 'circle', params: [1], hole: []}
+      var circle2 = {shape: 'circle', params: [2], hole: []}
+      var circle3 = {shape: 'circle', params: [3], hole: []}
+      var capturedWarning = null
 
       p.once('warning', function(w) {
-        expect(w.message).to.match(/already defined/)
-        expect(w.line).to.equal(9)
-        expect(p._tool.trace).to.eql([4])
-        done()
+        capturedWarning = w
       })
 
-      p.write({type: 'tool', code: '10', tool: circle, line: 8})
-      p.write({type: 'tool', code: '10', tool: rect, line: 9})
+      p.write({type: 'tool', code: '11', tool: circle1, line: 8})
+      p.write({type: 'tool', code: '12', tool: circle2, line: 9})
+      p.write({type: 'tool', code: '11', tool: circle3, line: 10})
+
+      expect(capturedWarning.message).to.match(/already defined/)
+      expect(capturedWarning.line).to.equal(10)
+      expect(p._tool).to.eql(p._tools['11'])
     })
 
     it('should not set trace for untraceable tools', function() {


### PR DESCRIPTION
The `v4` plotter no-ops when it receives tool definition commands for tools that are already defined. Drill files may repeat tool definitions as a way of calling out tool changes, for some reason.

This PR changes the behavior of the plotter to process the definition rather than ignore it. It still triggers a warning, but it will now process the definition and, importantly, change the active tool.

Closes #378