### PR TITLE
More supported Excellon commands

### DIFF
--- a/packages/parser/src/constants.ts
+++ b/packages/parser/src/constants.ts
@@ -40,10 +40,45 @@ export const SLOT = 'slot'
 export const LINE = 'line'
 export const CW_ARC = 'cwArc'
 export const CCW_ARC = 'ccwArc'
+export const ABSOLUTE_MODE = 'absoluteMode' // NC Drill G90
+export const INCREMENTAL_MODE = 'incrementalMode' // NC Drill G91
 
 // quadrant mode
 export const SINGLE = 'single'
 export const MULTI = 'multi'
+
+// drill mode
+export const DRILL_MODE = 'drillMode' // G05
+
+// drill absolute mode
+export const DRILL_ABSOLUTE_MODE = 'drillAbsoluteMode' // G90
+
+// Z-axis route
+export const DRILL_Z_AXIS_ROUTE_DEPTH = 'drillZAxisRouteDepth' // M14
+export const DRILL_Z_AXIS_ROUTE_POSITION = 'drillZAxisRoutePosition' // M15
+
+
+// Retracting
+export const DRILL_RETRACT_WITH_CLAMPING = 'drillRetractWithClamping' // M16
+export const DRILL_RETRACT_NO_CLAMPING = 'drillRetractNoClamping' // M17
+
+// tool tip chek
+export const DRILL_TOOL_TIP_CHECK = 'drillToolTipCheck' // M18
+
+// reference scaling
+export const DRILL_REF_SCALE_ON = 'drillRefScaleOn' // M60
+export const DRILL_REF_SCALE_OFF = 'drillRefScaleOff' // M61
+
+export const DRILL_PECK_ON = 'drillPeckOn' // M62
+export const DRILL_PECK_OFF = 'drillPeckOff' // M63
+
+// drill measuring modes
+export const DRILL_METRIC_MEASURE_MODE = 'drillMetricMeasureMode' // M71
+export const DRILL_INCH_MEASURE_MODE = 'drillInchMeasureMode' // M72
+
+// drill mirror image
+export const DRILL_MIRROR_IMAGE_X = 'drillMirrorImageX' // M80
+export const DRILL_MIRROR_IMAGE_Y = 'drillMirrorImageY' // M90
 
 // load polarity
 export const DARK = 'dark'

--- a/packages/parser/src/lexer/rules.ts
+++ b/packages/parser/src/lexer/rules.ts
@@ -64,7 +64,10 @@ export const rules: Rules = {
   },
   [Tokens.GERBER_STEP_REPEAT]: 'SR',
   [Tokens.GERBER_MACRO_VARIABLE]: /\$\d+/,
-  [Tokens.SEMICOLON]: ';',
+  [Tokens.DRILL_FORMAT]: {
+    match: /^;FILE_FORMAT=[0-9]:[0-9]/,
+    value: (text: string): string => text.slice(12),
+  },
   [Tokens.DRILL_UNITS]: /^(?:METRIC|INCH)/,
   [Tokens.DRILL_ZERO_INCLUSION]: {
     match: /,(?:TZ|LZ)/,
@@ -74,6 +77,7 @@ export const rules: Rules = {
   [Tokens.NUMBER]: /(?:[+-])?[\d.]+/,
   [Tokens.OPERATOR]: ['x', '/', '+', '-', '(', ')'],
   [Tokens.COMMA]: ',',
+  [Tokens.SEMICOLON]: ';',
   [Tokens.WORD]: /[a-zA-Z]+/,
   [Tokens.WHITESPACE]: /[ \t]+/,
   [Tokens.NEWLINE]: {

--- a/packages/parser/src/lexer/rules.ts
+++ b/packages/parser/src/lexer/rules.ts
@@ -66,7 +66,7 @@ export const rules: Rules = {
   [Tokens.GERBER_MACRO_VARIABLE]: /\$\d+/,
   [Tokens.DRILL_FORMAT]: {
     match: /^;FILE_FORMAT=[0-9]:[0-9]/,
-    value: (text: string): string => text.slice(12),
+    value: (text: string): string => text.slice(13),
   },
   [Tokens.DRILL_UNITS]: /^(?:METRIC|INCH)/,
   [Tokens.DRILL_ZERO_INCLUSION]: {

--- a/packages/parser/src/lexer/tokens.ts
+++ b/packages/parser/src/lexer/tokens.ts
@@ -120,7 +120,7 @@ export const GERBER_MACRO_VARIABLE = 'GERBER_MACRO_VARIABLE'
 export const SEMICOLON = 'SEMICOLON'
 
 /**
- * NC Drill file format token type 
+ * NC Drill file format token type
  */
 export const DRILL_FORMAT = 'DRILL_FORMAT'
 

--- a/packages/parser/src/lexer/tokens.ts
+++ b/packages/parser/src/lexer/tokens.ts
@@ -120,6 +120,11 @@ export const GERBER_MACRO_VARIABLE = 'GERBER_MACRO_VARIABLE'
 export const SEMICOLON = 'SEMICOLON'
 
 /**
+ * NC Drill file format token type 
+ */
+export const DRILL_FORMAT = 'DRILL_FORMAT'
+
+/**
  * Drill file units token type
  *
  * @category Lexer
@@ -204,9 +209,10 @@ export type TokenType =
   | typeof GERBER_LOAD_POLARITY
   | typeof GERBER_STEP_REPEAT
   | typeof GERBER_MACRO_VARIABLE
-  | typeof SEMICOLON
   | typeof DRILL_UNITS
+  | typeof DRILL_FORMAT
   | typeof DRILL_ZERO_INCLUSION
+  | typeof SEMICOLON
   | typeof COORD_CHAR
   | typeof NUMBER
   | typeof WORD

--- a/packages/parser/src/syntax/drill.ts
+++ b/packages/parser/src/syntax/drill.ts
@@ -12,7 +12,32 @@ import {
   tokensToMode,
   tokensToString,
   tokensToPosition,
+  tokensToDrillMCode,
 } from './map-tokens'
+
+const drillCommands: SyntaxRule = {
+  rules: [
+    one([
+      token(Lexer.M_CODE, '14'),
+      token(Lexer.M_CODE, '15'),
+      token(Lexer.M_CODE, '16'),
+      token(Lexer.M_CODE, '17'),
+      token(Lexer.M_CODE, '18'),
+    ]),
+    token(Lexer.NEWLINE),
+  ],
+  createNodes: tokens => {
+    const nodes: Tree.ChildNode[] = [
+      {
+        type: Tree.DRILL_M_CODE,
+        position: tokensToPosition(tokens.slice(0, 2)),
+        code: tokensToDrillMCode(tokens) as Types.DrillMCodeType,
+      },
+    ]
+
+    return nodes
+  },
+}
 
 const units: SyntaxRule = {
   rules: [
@@ -125,6 +150,7 @@ const mode: SyntaxRule = {
       token(Lexer.G_CODE, '2'),
       token(Lexer.G_CODE, '3'),
       token(Lexer.G_CODE, '5'),
+      token(Lexer.G_CODE, '90'),
     ]),
     token(Lexer.NEWLINE),
   ],
@@ -233,10 +259,7 @@ const headerEnd: SyntaxRule = {
 }
 
 const done: SyntaxRule = {
-  rules: [
-    one([token(Lexer.M_CODE, '30'), token(Lexer.M_CODE, '0')]),
-    token(Lexer.NEWLINE),
-  ],
+  rules: [one([token(Lexer.M_CODE, '30'), token(Lexer.M_CODE, '0')])],
   createNodes: tokens => [
     {type: Tree.DONE, position: tokensToPosition(tokens)},
   ],
@@ -260,6 +283,7 @@ const comment: SyntaxRule = {
 export const drillSyntax: Array<SyntaxRule> = [
   tool,
   mode,
+  drillCommands,
   operation,
   slot,
   headerStart,

--- a/packages/parser/src/syntax/drill.ts
+++ b/packages/parser/src/syntax/drill.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // drill file grammar
 import * as Lexer from '../lexer'
 import * as Tree from '../tree'
@@ -61,11 +62,9 @@ const units: SyntaxRule = {
         zeroSuppression,
       })
     }
-
     return nodes
   },
 }
-
 const tool: SyntaxRule = {
   rules: [
     token(Lexer.T_CODE),
@@ -191,6 +190,23 @@ const slot: SyntaxRule = {
   },
 }
 
+const headerStart: SyntaxRule = {
+  rules: [token(Lexer.M_CODE, '48'), token(Lexer.NEWLINE)],
+  createNodes: tokens => [
+    {type: Tree.HEADER_START, position: tokensToPosition(tokens)},
+  ],
+}
+
+const headerEnd: SyntaxRule = {
+  rules: [
+    one([token(Lexer.PERCENT), token(Lexer.M_CODE, '95')]),
+    token(Lexer.NEWLINE),
+  ],
+  createNodes: tokens => [
+    {type: Tree.HEADER_END, position: tokensToPosition(tokens)},
+  ],
+}
+
 const done: SyntaxRule = {
   rules: [
     one([token(Lexer.M_CODE, '30'), token(Lexer.M_CODE, '0')]),
@@ -221,6 +237,8 @@ export const drillSyntax: Array<SyntaxRule> = [
   mode,
   operation,
   slot,
+  headerStart,
+  headerEnd,
   comment,
   units,
   done,

--- a/packages/parser/src/syntax/drill.ts
+++ b/packages/parser/src/syntax/drill.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 // drill file grammar
 import * as Lexer from '../lexer'
 import * as Tree from '../tree'
@@ -71,7 +70,6 @@ const units: SyntaxRule = {
       .filter(t => t.type === Lexer.NUMBER)
       .reduce<Types.Format | null>((_, t) => {
         const [integer = '', decimal = ''] = t.value.split('.')
-        console.log('format found', [integer.length, decimal.length])
         return [integer.length, decimal.length]
       }, null)
 

--- a/packages/parser/src/syntax/drill.ts
+++ b/packages/parser/src/syntax/drill.ts
@@ -46,6 +46,7 @@ const units: SyntaxRule = {
       .filter(t => t.type === Lexer.NUMBER)
       .reduce<Types.Format | null>((_, t) => {
         const [integer = '', decimal = ''] = t.value.split('.')
+        console.log('format found', [integer.length, decimal.length])
         return [integer.length, decimal.length]
       }, null)
 
@@ -62,9 +63,33 @@ const units: SyntaxRule = {
         zeroSuppression,
       })
     }
+
     return nodes
   },
 }
+
+const drillFormat: SyntaxRule = {
+  rules: [token(Lexer.DRILL_FORMAT)],
+
+  createNodes: tokens => {
+    const format: Types.Format = [
+      parseInt(tokens[0].value[0]),
+      parseInt(tokens[0].value[2]),
+    ]
+    const node: Tree.ChildNode[] = [
+      {
+        type: Tree.COORDINATE_FORMAT,
+        position: tokensToPosition(tokens),
+        mode: null,
+        format,
+        zeroSuppression: null,
+      },
+    ]
+
+    return node
+  },
+}
+
 const tool: SyntaxRule = {
   rules: [
     token(Lexer.T_CODE),
@@ -241,5 +266,6 @@ export const drillSyntax: Array<SyntaxRule> = [
   headerEnd,
   comment,
   units,
+  drillFormat,
   done,
 ].map(r => ({...r, filetype: Constants.DRILL}))

--- a/packages/parser/src/syntax/map-tokens.ts
+++ b/packages/parser/src/syntax/map-tokens.ts
@@ -1,7 +1,30 @@
 import {Position} from 'unist'
-import {Token, NUMBER, COORD_CHAR, G_CODE, D_CODE} from '../lexer'
-import {Coordinates, InterpolateModeType, GraphicType} from '../types'
-import {SEGMENT, MOVE, SHAPE, LINE, CW_ARC, CCW_ARC, DRILL} from '../constants'
+import {Token, NUMBER, COORD_CHAR, G_CODE, D_CODE, M_CODE} from '../lexer'
+import {
+  Coordinates,
+  InterpolateModeType,
+  GraphicType,
+  DrillMCodeType,
+} from '../types'
+import {
+  SEGMENT,
+  MOVE,
+  SHAPE,
+  LINE,
+  CW_ARC,
+  CCW_ARC,
+  DRILL,
+  DRILL_INCH_MEASURE_MODE,
+} from '../constants'
+import {
+  DRILL_ABSOLUTE_MODE,
+  DRILL_METRIC_MEASURE_MODE,
+  DRILL_RETRACT_WITH_CLAMPING,
+  DRILL_RETRACT_NO_CLAMPING,
+  DRILL_Z_AXIS_ROUTE_DEPTH,
+  DRILL_Z_AXIS_ROUTE_POSITION,
+  DRILL_TOOL_TIP_CHECK,
+} from '..'
 
 export function tokensToCoordinates(tokens: Array<Token>): Coordinates {
   return tokens.reduce<Coordinates>((coords, token, i) => {
@@ -24,7 +47,23 @@ export function tokensToMode(tokens: Token[]): InterpolateModeType {
       if (t.value === '2') return CW_ARC
       if (t.value === '3') return CCW_ARC
       if (t.value === '5') return DRILL
+      if (t.value === '90') return DRILL_ABSOLUTE_MODE
       return m
+    }, null)
+}
+
+export function tokensToDrillMCode(tokens: Token[]): DrillMCodeType {
+  return tokens
+    .filter(t => t.type === M_CODE)
+    .reduce<DrillMCodeType>((d, c) => {
+      if (c.value === '14') return DRILL_Z_AXIS_ROUTE_DEPTH
+      if (c.value === '15') return DRILL_Z_AXIS_ROUTE_POSITION
+      if (c.value === '16') return DRILL_RETRACT_WITH_CLAMPING
+      if (c.value === '17') return DRILL_RETRACT_NO_CLAMPING
+      if (c.value === '18') return DRILL_TOOL_TIP_CHECK
+      if (c.value === '71') return DRILL_METRIC_MEASURE_MODE
+      if (c.value === '72') return DRILL_INCH_MEASURE_MODE
+      return d
     }, null)
 }
 

--- a/packages/parser/src/tree.ts
+++ b/packages/parser/src/tree.ts
@@ -1,4 +1,5 @@
 import {Position} from 'unist'
+// import { G_CODE, M_CODE } from '.'
 
 import * as Types from './types'
 
@@ -24,13 +25,13 @@ export const COMMENT = 'comment'
 export const DONE = 'done'
 
 /**
- * {@linkcode headerStart} node type 
+ * {@linkcode headerStart} node type
  * @category Node
  */
- export const HEADER_START = 'headerStart'
+export const HEADER_START = 'headerStart'
 
 /**
- * {@linkcode headerEnd} node type 
+ * {@linkcode headerEnd} node type
  * @category Node
  */
 export const HEADER_END = 'headerEnd'
@@ -140,6 +141,10 @@ export const MACRO_VARIABLE = 'macroVariable'
  */
 export const MACRO_PRIMITIVE = 'macroPrimitive'
 
+export const DRILL_M_CODE = 'drillMCode'
+
+export const DRILL_G_CODE = 'drillGCode'
+
 interface BaseNode {
   type: string
   /** Location in the source file the node was parsed from */
@@ -178,6 +183,8 @@ export type ChildNode =
   | LoadPolarity
   | StepRepeat
   | Graphic
+  | DrillGCode
+  | DrillMCode
   | Unimplemented
 
 /**
@@ -238,25 +245,37 @@ export interface Done extends BaseNode {
 
 /**
  * Node representing an end of header comment that can appear in NC Drill files. This represents M95
- * 
+ *
  * @category Node
  */
 
- export interface HeaderStart extends BaseNode {
+export interface HeaderStart extends BaseNode {
   /** Node type */
   type: typeof HEADER_START
 }
 
 /**
- * Node representing an end of header comment that can appear in NC Drill files. This represents either 
+ * Node representing an end of header comment that can appear in NC Drill files. This represents either
  * an PERCENT symbol '%' or 'M95'.
- * 
+ *
  * @category Node
  */
 
 export interface HeaderEnd extends BaseNode {
   /** Node type */
   type: typeof HEADER_END
+}
+
+export interface DrillMCode extends BaseNode {
+  type: typeof DRILL_M_CODE
+
+  code: Types.DrillMCodeType
+}
+
+export interface DrillGCode extends BaseNode {
+  type: typeof DRILL_G_CODE
+
+  code: Types.DrillGCodeType
 }
 
 /**
@@ -492,6 +511,21 @@ export interface Graphic extends BaseNode {
   graphic: Types.GraphicType
   /** Coordinates where the graphic will be applied */
   coordinates: Types.Coordinates
+}
+
+/**
+ *
+ */
+export interface DrillGCode extends BaseNode {
+  type: typeof DRILL_G_CODE
+
+  code: Types.DrillGCodeType
+}
+
+export interface DrillMCode extends BaseNode {
+  type: typeof DRILL_M_CODE
+
+  code: Types.DrillMCodeType
 }
 
 /**

--- a/packages/parser/src/tree.ts
+++ b/packages/parser/src/tree.ts
@@ -24,6 +24,18 @@ export const COMMENT = 'comment'
 export const DONE = 'done'
 
 /**
+ * {@linkcode headerStart} node type 
+ * @category Node
+ */
+ export const HEADER_START = 'headerStart'
+
+/**
+ * {@linkcode headerEnd} node type 
+ * @category Node
+ */
+export const HEADER_END = 'headerEnd'
+
+/**
  * {@linkcode Units} node type
  *
  * @category Node
@@ -153,6 +165,8 @@ export type Node = Root | ChildNode
 export type ChildNode =
   | Comment
   | Done
+  | HeaderStart
+  | HeaderEnd
   | Units
   | CoordinateFormat
   | ToolDefinition
@@ -220,6 +234,29 @@ export interface Comment extends BaseNode {
 export interface Done extends BaseNode {
   /** Node type */
   type: typeof DONE
+}
+
+/**
+ * Node representing an end of header comment that can appear in NC Drill files. This represents M95
+ * 
+ * @category Node
+ */
+
+ export interface HeaderStart extends BaseNode {
+  /** Node type */
+  type: typeof HEADER_START
+}
+
+/**
+ * Node representing an end of header comment that can appear in NC Drill files. This represents either 
+ * an PERCENT symbol '%' or 'M95'.
+ * 
+ * @category Node
+ */
+
+export interface HeaderEnd extends BaseNode {
+  /** Node type */
+  type: typeof HEADER_END
 }
 
 /**

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -170,6 +170,8 @@ export type InterpolateModeType =
   | typeof Constants.CCW_ARC
   | typeof Constants.MOVE
   | typeof Constants.DRILL
+  | typeof Constants.DRILL_MODE
+  | typeof Constants.DRILL_ABSOLUTE_MODE
   | null
 
 /**
@@ -184,3 +186,30 @@ export type QuadrantModeType =
  * Valid image polarities
  */
 export type Polarity = typeof Constants.DARK | typeof Constants.CLEAR
+
+/**
+ * Valid drill G codes
+ */
+export type DrillGCodeType =
+  | typeof Constants.DRILL_MODE
+  | typeof Constants.DRILL_ABSOLUTE_MODE
+  | null
+
+/**
+ * Valid drill M codes
+ */
+export type DrillMCodeType =
+  | typeof Constants.DRILL_Z_AXIS_ROUTE_DEPTH
+  | typeof Constants.DRILL_Z_AXIS_ROUTE_POSITION
+  | typeof Constants.DRILL_RETRACT_WITH_CLAMPING
+  | typeof Constants.DRILL_RETRACT_NO_CLAMPING
+  | typeof Constants.DRILL_TOOL_TIP_CHECK
+  | typeof Constants.DRILL_REF_SCALE_ON
+  | typeof Constants.DRILL_REF_SCALE_OFF
+  | typeof Constants.DRILL_PECK_ON
+  | typeof Constants.DRILL_PECK_OFF
+  | typeof Constants.DRILL_METRIC_MEASURE_MODE
+  | typeof Constants.DRILL_INCH_MEASURE_MODE
+  | typeof Constants.DRILL_MIRROR_IMAGE_X
+  | typeof Constants.DRILL_MIRROR_IMAGE_Y
+  | null


### PR DESCRIPTION
I've made some changes to the gerber-parser package, adding support for Excellon drill header commands, ;FILE_FORMAT and a number of M and G codes. 

Feel free to make any comments or changes where necessary. :)
