### PR TITLE
fix(parser): recognize drill file header markers

### DIFF
--- a/packages/parser/src/syntax/__tests__/drill.test.ts
+++ b/packages/parser/src/syntax/__tests__/drill.test.ts
@@ -30,6 +30,28 @@ const SPECS: Array<{
   expectedNodes: Tree.ChildNode[]
 }> = [
   {
+    // Drill file start with a percent header
+    source: '%\n',
+    expectedTokens: [t(Lexer.PERCENT, '%'), t(Lexer.NEWLINE, '\n')],
+    expectedNodes: [
+      {
+        type: Tree.DRILL_HEADER,
+        position: pos([1, 1, 0], [1, 2, 1]),
+      },
+    ],
+  },
+  {
+    // Drill file start with an M48 header
+    source: 'M48\n',
+    expectedTokens: [t(Lexer.M_CODE, '48'), t(Lexer.NEWLINE, '\n')],
+    expectedNodes: [
+      {
+        type: Tree.DRILL_HEADER,
+        position: pos([1, 1, 0], [1, 4, 3]),
+      },
+    ],
+  },
+  {
     // Drill file end with M00
     source: 'M00\n',
     expectedTokens: [t(Lexer.M_CODE, '0'), t(Lexer.NEWLINE, '\n')],

--- a/packages/parser/src/syntax/drill.ts
+++ b/packages/parser/src/syntax/drill.ts
@@ -209,6 +209,17 @@ const done: SyntaxRule = {
   ],
 }
 
+const header: SyntaxRule = {
+  name: 'header',
+  rules: [
+    one([token(Lexer.M_CODE, '48'), token(Lexer.PERCENT)]),
+    token(Lexer.NEWLINE),
+  ],
+  createNodes: tokens => [
+    {type: Tree.DRILL_HEADER, position: tokensToPosition(tokens)},
+  ],
+}
+
 const comment: SyntaxRule = {
   name: 'comment',
   rules: [
@@ -233,4 +244,5 @@ export const drillGrammar: SyntaxRule[] = [
   comment,
   units,
   done,
+  header,
 ].map(r => ({...r, filetype: Constants.DRILL}))

--- a/packages/parser/src/tree.ts
+++ b/packages/parser/src/tree.ts
@@ -17,6 +17,13 @@ export const ROOT = 'root'
 export const COMMENT = 'comment'
 
 /**
+ * {@linkcode DrillHeader} node type
+ *
+ * @category Node
+ */
+export const DRILL_HEADER = 'drillHeader'
+
+/**
  * {@linkcode Done} node type
  *
  * @category Node
@@ -152,6 +159,7 @@ export type Node = Root | ChildNode
  */
 export type ChildNode =
   | Comment
+  | DrillHeader
   | Done
   | Units
   | CoordinateFormat
@@ -207,6 +215,16 @@ export interface Comment extends BaseNode {
   type: typeof COMMENT
   /** Contents of the comment as a string */
   comment: string
+}
+
+/**
+ * Node representing drill file's header start or end.
+ *
+ *  @category Node
+ */
+export interface DrillHeader extends BaseNode {
+  /** Node type */
+  type: typeof DRILL_HEADER
 }
 
 /**


### PR DESCRIPTION
This PR pulls a specific change - drill file header parsing - out of #385 by @hartley9, because it turns out we need that or else lots of drill files won't parse properly!