### PR TITLE
fix: prevent potential error by adding null check for tool.trace

### DIFF
--- a/packages/gerber-plotter/lib/plotter.js
+++ b/packages/gerber-plotter/lib/plotter.js
@@ -87,7 +87,7 @@ Plotter.prototype._finishPath = function(doNotOptimize) {
     // check for outline tool
     var tool = !this._plotAsOutline ? this._tool : this._outTool
 
-    if (!this._region && tool.trace.length === 1) {
+    if (!this._region && tool?.trace && tool.trace.length === 1) {
       this.push({type: 'stroke', width: tool.trace[0], path: path})
     } else {
       this.push({type: 'fill', path: path})


### PR DESCRIPTION
[ErrorGerber.zip](https://github.com/user-attachments/files/19064822/ErrorGerber.zip)

While converting a Gerber ZIP file to SVG using the PCB Stackup library, I encountered a TypeError in the plotter.js file within the gerber-plotter package. This issue causes the Node.js server to crash, making it impossible to proceed with the conversion.

**Error Details**
The error occurs when running the following code:
```
const layers = files.map(unzipFile => ({
    filename: unzipFile,
    gerber: fs.createReadStream(path.join(unzip_gerber_dir, unzipFile)),
}));
const stackup = await pcbStackup(layers);
```

When calling pcbStackup(layers), the Gerber Plotter package throws a TypeError due to tool.trace being undefined.
**Error:**
if (!this._region && tool.trace.length === 1) {
                              ^
TypeError: Cannot read properties of null (reading 'trace')

The error originates from plotter.js, where the code attempts to access .length on tool.trace, which is null or undefined.

Since the error is unhandled, it crashes the entire Node.js server instead of failing gracefully.

**Root Cause**

- The provided Gerber ZIP file has formatting issues, leading to tool.trace being undefined in certain cases.
- The Gerber Plotter package does not currently check for null values before accessing .length.

**Solution**

- Added a null check for tool.trace in plotter.js, ensuring that .length is only accessed when tool.trace is valid.
- Prevented the error from propagating and crashing the Node.js server.